### PR TITLE
feat: Routes for Blocks and Transactions

### DIFF
--- a/client/.env
+++ b/client/.env
@@ -1,1 +1,1 @@
-REACT_APP_API_PATH=/api/v1/
+REACT_APP_API_PATH=/api/v1

--- a/client/src/features/neighborhoods/components/blocks.tsx
+++ b/client/src/features/neighborhoods/components/blocks.tsx
@@ -22,10 +22,16 @@ interface BlockSummary {
   dateTime: string;
 }
 
-export function NeighborhoodBlocks({ id }: { id: number }) {
+interface NeighborhoodBlocksProps {
+  id: number;
+  page?: number;
+  limit?: number;
+}
+
+export function NeighborhoodBlocks({ id, page = 1 }: NeighborhoodBlocksProps) {
   const query = useQuery(
-    ["neighborhoods", id, "blocks"],
-    getNeighborhoodBlocks(id),
+    ["neighborhoods", id, "blocks", page],
+    getNeighborhoodBlocks(id, { page }),
   );
 
   return (

--- a/client/src/features/neighborhoods/components/blocks.tsx
+++ b/client/src/features/neighborhoods/components/blocks.tsx
@@ -14,6 +14,7 @@ import {
 } from "@liftedinit/ui";
 import { abbr, ago, ErrorAlert } from "../../../shared";
 import { getNeighborhoodBlocks } from "../queries";
+import { useEffect } from "react";
 
 interface BlockSummary {
   height: number;
@@ -25,14 +26,23 @@ interface BlockSummary {
 interface NeighborhoodBlocksProps {
   id: number;
   page?: number;
-  limit?: number;
+  setTotalPages?: (p: number) => void;
 }
 
-export function NeighborhoodBlocks({ id, page = 1 }: NeighborhoodBlocksProps) {
+export function NeighborhoodBlocks({
+  id,
+  page = 1,
+  setTotalPages,
+}: NeighborhoodBlocksProps) {
   const query = useQuery(
     ["neighborhoods", id, "blocks", page],
     getNeighborhoodBlocks(id, { page }),
   );
+  useEffect(() => {
+    if (setTotalPages && query.data) {
+      setTotalPages(query.data.meta.totalPages);
+    }
+  }, [setTotalPages, query.data]);
 
   return (
     <Box bg="white" my={6} p={6}>

--- a/client/src/features/neighborhoods/components/transactions.tsx
+++ b/client/src/features/neighborhoods/components/transactions.tsx
@@ -26,10 +26,19 @@ interface TransactionSummary {
   dateTime: string;
 }
 
-export function NeighborhoodTransactions({ id }: { id: number }) {
+interface NeighborhoodTransactionsProps {
+  id: number;
+  page?: number;
+  limit?: number;
+}
+
+export function NeighborhoodTransactions({
+  id,
+  page = 1,
+}: NeighborhoodTransactionsProps) {
   const query = useQuery(
-    ["neighborhoods", id, "transactions"],
-    getNeighborhoodTransactions(id),
+    ["neighborhoods", id, "transactions", page],
+    getNeighborhoodTransactions(id, { page }),
   );
 
   return (

--- a/client/src/features/neighborhoods/components/transactions.tsx
+++ b/client/src/features/neighborhoods/components/transactions.tsx
@@ -15,6 +15,7 @@ import {
 } from "@liftedinit/ui";
 import { abbr, ago, by, ErrorAlert } from "../../../shared";
 import { getNeighborhoodTransactions } from "../queries";
+import { useEffect } from "react";
 
 interface TransactionSummary {
   hash: string;
@@ -29,17 +30,23 @@ interface TransactionSummary {
 interface NeighborhoodTransactionsProps {
   id: number;
   page?: number;
-  limit?: number;
+  setTotalPages?: (p: number) => void;
 }
 
 export function NeighborhoodTransactions({
   id,
   page = 1,
+  setTotalPages,
 }: NeighborhoodTransactionsProps) {
   const query = useQuery(
     ["neighborhoods", id, "transactions", page],
     getNeighborhoodTransactions(id, { page }),
   );
+  useEffect(() => {
+    if (setTotalPages && query.data) {
+      setTotalPages(query.data.meta.totalPages);
+    }
+  }, [setTotalPages, query.data]);
 
   return (
     <Box bg="white" my={6} p={6}>

--- a/client/src/features/neighborhoods/queries.ts
+++ b/client/src/features/neighborhoods/queries.ts
@@ -1,25 +1,26 @@
-function get(...path: (string | number)[]) {
-  return async function () {
-    const res = await fetch(process.env.REACT_APP_API_PATH + path.join("/"));
-    if (res.ok) {
-      return await res.json();
-    }
-    throw new Error(`${res.statusText} (${res.status})`);
-  };
-}
+import { get } from "../../shared";
+
+const PAGE = 1;
+const LIMIT = 10;
 
 export function getNeighborhoods() {
   return get("neighborhoods");
 }
 
 export function getNeighborhood(id: number) {
-  return get("neighborhoods", id);
+  return get(`neighborhoods/${id}`);
 }
 
-export function getNeighborhoodBlocks(id: number) {
-  return get("neighborhoods", id, "blocks");
+export function getNeighborhoodBlocks(
+  id: number,
+  { page = PAGE, limit = LIMIT },
+) {
+  return get(`neighborhoods/${id}/blocks`, { page, limit });
 }
 
-export function getNeighborhoodTransactions(id: number) {
-  return get("neighborhoods", id, "transactions");
+export function getNeighborhoodTransactions(
+  id: number,
+  { page = PAGE, limit = LIMIT },
+) {
+  return get(`neighborhoods/${id}/transactions`, { page, limit });
 }

--- a/client/src/shared/utils.ts
+++ b/client/src/shared/utils.ts
@@ -29,3 +29,16 @@ export function by<T>(attr: keyof T) {
     return a[attr] < b[attr];
   };
 }
+
+export function get(path: string, params = {}) {
+  return async function () {
+    const query = new URLSearchParams(params).toString();
+    const url = `${process.env.REACT_APP_API_PATH}/${path}?${query}`;
+    console.log(url);
+    const res = await fetch(url);
+    if (res.ok) {
+      return await res.json();
+    }
+    throw new Error(`${res.statusText} (${res.status})`);
+  };
+}

--- a/client/src/shared/utils.ts
+++ b/client/src/shared/utils.ts
@@ -34,7 +34,6 @@ export function get(path: string, params = {}) {
   return async function () {
     const query = new URLSearchParams(params).toString();
     const url = `${process.env.REACT_APP_API_PATH}/${path}?${query}`;
-    console.log(url);
     const res = await fetch(url);
     if (res.ok) {
       return await res.json();

--- a/client/src/views/app.tsx
+++ b/client/src/views/app.tsx
@@ -1,10 +1,21 @@
-import { Route, Routes } from "react-router-dom";
-import { Home } from "../views";
+import { Outlet, Route, Routes } from "react-router-dom";
+import { Blocks, Home, Layout, Transactions } from "../views";
 
 export function App() {
   return (
     <Routes>
-      <Route index element={<Home />} />
+      <Route
+        path="/"
+        element={
+          <Layout>
+            <Outlet />
+          </Layout>
+        }
+      >
+        <Route index element={<Home />} />
+        <Route path="blocks" element={<Blocks />} />
+        <Route path="transactions" element={<Transactions />} />
+      </Route>
     </Routes>
   );
 }

--- a/client/src/views/blocks.tsx
+++ b/client/src/views/blocks.tsx
@@ -1,0 +1,22 @@
+import { Box, Button, ButtonGroup, Center } from "@liftedinit/ui";
+import React from "react";
+import { NeighborhoodBlocks } from "../features/neighborhoods";
+
+export function Blocks() {
+  const [page, setPage] = React.useState(1);
+  const neighborhoodId = 1; // @TODO: Get this from context
+
+  return (
+    <Box my={6}>
+      <NeighborhoodBlocks id={neighborhoodId} page={page} />
+      <Center my={6}>
+        <ButtonGroup isAttached>
+          <Button onClick={() => setPage(page - 1)} isDisabled={page === 1}>
+            Previous
+          </Button>
+          <Button onClick={() => setPage(page + 1)}>Next</Button>
+        </ButtonGroup>
+      </Center>
+    </Box>
+  );
+}

--- a/client/src/views/blocks.tsx
+++ b/client/src/views/blocks.tsx
@@ -1,20 +1,30 @@
 import { Box, Button, ButtonGroup, Center } from "@liftedinit/ui";
-import React from "react";
+import { useState } from "react";
 import { NeighborhoodBlocks } from "../features/neighborhoods";
 
 export function Blocks() {
-  const [page, setPage] = React.useState(1);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
   const neighborhoodId = 1; // @TODO: Get this from context
 
   return (
     <Box my={6}>
-      <NeighborhoodBlocks id={neighborhoodId} page={page} />
+      <NeighborhoodBlocks
+        id={neighborhoodId}
+        page={page}
+        setTotalPages={setTotalPages}
+      />
       <Center my={6}>
         <ButtonGroup isAttached>
           <Button onClick={() => setPage(page - 1)} isDisabled={page === 1}>
             Previous
           </Button>
-          <Button onClick={() => setPage(page + 1)}>Next</Button>
+          <Button
+            onClick={() => setPage(page + 1)}
+            isDisabled={page >= totalPages}
+          >
+            Next
+          </Button>
         </ButtonGroup>
       </Center>
     </Box>

--- a/client/src/views/home.tsx
+++ b/client/src/views/home.tsx
@@ -1,4 +1,5 @@
-import { Container, Divider, Heading, SimpleGrid, Text } from "@liftedinit/ui";
+import { Box, Button, Center, Divider, SimpleGrid } from "@liftedinit/ui";
+import { Link } from "react-router-dom";
 import {
   NeighborhoodBlocks,
   NeighborhoodStatus,
@@ -9,16 +10,27 @@ export function Home() {
   const neighborhoodId = 1; // @TODO: Get this from context
 
   return (
-    <Container maxW="container.lg">
-      <Heading my={6}>Talib</Heading>
-      <Text>A Block Explorer for the Many Protocol</Text>
-      <Divider my={6} />
+    <>
       <NeighborhoodStatus id={neighborhoodId} />
       <Divider my={6} />
       <SimpleGrid columns={2} spacing={6}>
-        <NeighborhoodBlocks id={neighborhoodId} />
-        <NeighborhoodTransactions id={neighborhoodId} />
+        <Box>
+          <NeighborhoodBlocks id={neighborhoodId} />
+          <Center>
+            <Button as={Link} to="blocks">
+              More
+            </Button>
+          </Center>
+        </Box>
+        <Box>
+          <NeighborhoodTransactions id={neighborhoodId} />
+          <Center>
+            <Button as={Link} to="transactions">
+              More
+            </Button>
+          </Center>
+        </Box>
       </SimpleGrid>
-    </Container>
+    </>
   );
 }

--- a/client/src/views/index.ts
+++ b/client/src/views/index.ts
@@ -1,3 +1,6 @@
 export { App } from "./app";
 export { AppProvider } from "./app.provider";
+export { Blocks } from "./blocks";
 export { Home } from "./home";
+export { Layout } from "./layout";
+export { Transactions } from "./transactions";

--- a/client/src/views/layout.tsx
+++ b/client/src/views/layout.tsx
@@ -1,0 +1,15 @@
+import { Container, Divider, Heading, Text } from "@liftedinit/ui";
+import { Link } from "react-router-dom";
+
+export function Layout({ children }: React.PropsWithChildren<{}>) {
+  return (
+    <Container maxW="container.lg">
+      <Heading my={6}>
+        <Link to="/">Talib</Link>
+      </Heading>
+      <Text>A Block Explorer for the Many Protocol</Text>
+      <Divider my={6} />
+      {children}
+    </Container>
+  );
+}

--- a/client/src/views/transactions.tsx
+++ b/client/src/views/transactions.tsx
@@ -1,20 +1,30 @@
 import { Box, Button, ButtonGroup, Center } from "@liftedinit/ui";
-import React from "react";
+import { useState } from "react";
 import { NeighborhoodTransactions } from "../features/neighborhoods";
 
 export function Transactions() {
-  const [page, setPage] = React.useState(1);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
   const neighborhoodId = 1; // @TODO: Get this from context
 
   return (
     <Box my={6}>
-      <NeighborhoodTransactions id={neighborhoodId} page={page} />
+      <NeighborhoodTransactions
+        id={neighborhoodId}
+        page={page}
+        setTotalPages={setTotalPages}
+      />
       <Center my={6}>
         <ButtonGroup isAttached>
           <Button onClick={() => setPage(page - 1)} isDisabled={page === 1}>
             Previous
           </Button>
-          <Button onClick={() => setPage(page + 1)}>Next</Button>
+          <Button
+            onClick={() => setPage(page + 1)}
+            isDisabled={page >= totalPages}
+          >
+            Next
+          </Button>
         </ButtonGroup>
       </Center>
     </Box>

--- a/client/src/views/transactions.tsx
+++ b/client/src/views/transactions.tsx
@@ -1,0 +1,22 @@
+import { Box, Button, ButtonGroup, Center } from "@liftedinit/ui";
+import React from "react";
+import { NeighborhoodTransactions } from "../features/neighborhoods";
+
+export function Transactions() {
+  const [page, setPage] = React.useState(1);
+  const neighborhoodId = 1; // @TODO: Get this from context
+
+  return (
+    <Box my={6}>
+      <NeighborhoodTransactions id={neighborhoodId} page={page} />
+      <Center my={6}>
+        <ButtonGroup isAttached>
+          <Button onClick={() => setPage(page - 1)} isDisabled={page === 1}>
+            Previous
+          </Button>
+          <Button onClick={() => setPage(page + 1)}>Next</Button>
+        </ButtonGroup>
+      </Center>
+    </Box>
+  );
+}


### PR DESCRIPTION
**Home Page**

<img width="1920" alt="Screenshot 2023-03-08 at 11 03 30 AM" src="https://user-images.githubusercontent.com/405258/223811839-c2f5e47b-943e-41c2-ab7b-87af967489bd.png">


**Blocks**

<img width="1920" alt="Screenshot 2023-03-08 at 11 03 37 AM" src="https://user-images.githubusercontent.com/405258/223812793-ccc42253-2dd6-4ced-9508-a2eb3e998292.png">


**Transactions**

<img width="1920" alt="Screenshot 2023-03-08 at 11 03 46 AM" src="https://user-images.githubusercontent.com/405258/223812850-4094a3d8-ca68-4151-88bd-e076fb584cd0.png">

- [x] Link to Blocks, Transactions pages
- [x] Links back to home (click on "Talib")
- [x] Previous/Next buttons page through history
- [x] Next button is disabled when you run out of history 😢 