### PR TITLE
perf: better SQL for blocks

### DIFF
--- a/server/src/neighborhoods/blocks/block.service.ts
+++ b/server/src/neighborhoods/blocks/block.service.ts
@@ -68,6 +68,7 @@ export class BlockService {
   ): Promise<Pagination<Block>> {
     let query = this.blockRepository
       .createQueryBuilder("b")
+      .select(["b.height", "b.time", "b.hash", "b.appHash"])
       .loadRelationCountAndMap("b.txCount", "b.transactions", "transactions")
       .addSelect("COUNT(transactions.id) as txCount")
       .leftJoin("b.transactions", "transactions")

--- a/server/src/neighborhoods/blocks/block.service.ts
+++ b/server/src/neighborhoods/blocks/block.service.ts
@@ -72,7 +72,7 @@ export class BlockService {
       .loadRelationCountAndMap("b.txCount", "b.transactions", "transactions")
       .addSelect("COUNT(transactions.id) as txCount")
       .leftJoin("b.transactions", "transactions")
-      .groupBy("transactions.id, b.id")
+      .groupBy("transactions.id, b.height, b.time, b.hash, b.appHash")
       .where({ neighborhood: { id: neighborhoodId } })
       .orderBy("height", "DESC");
 


### PR DESCRIPTION
Not selecting ID means we don't sort by it when grouping (then re-sort using height). 