### PR TITLE
fix: Change idstore.store pretty method name

### DIFF
--- a/client/src/shared/components/txn-list.tsx
+++ b/client/src/shared/components/txn-list.tsx
@@ -22,7 +22,7 @@ const PrettyMethods: { [name: string]: string } = {
   "account.multisigApprove": "Approve",
   "account.multisigRevoke": "Revoke",
   "account.multisigSubmitTransaction": "Submit",
-  "idstore.store": "Put",
+  "idstore.store": "Register",
 };
 
 interface TxnSummary {


### PR DESCRIPTION
Was "Put" because I thought it was `kvstore.store` but now it's "Register" because it's `idstore.store`.