### PR TITLE
feat: Address Details page

### DIFF
--- a/client/src/api/queries.ts
+++ b/client/src/api/queries.ts
@@ -32,3 +32,7 @@ export function getNeighborhoodBlock(id: number, hash: string) {
 export function getNeighborhoodTransaction(id: number, hash: string) {
   return get(`neighborhoods/${id}/transactions/${hash}`);
 }
+
+export function getNeighborhoodAddress(id: number, address: string) {
+  return get(`neighborhoods/${id}/addresses/${address}`);
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -5,7 +5,15 @@ import ReactDOM from "react-dom";
 import { HashRouter, Outlet, Route, Routes } from "react-router-dom";
 
 import { NeighborhoodProvider } from "api";
-import { Block, Blocks, Home, Layout, Transaction, Transactions } from "pages";
+import {
+  Address,
+  Block,
+  Blocks,
+  Home,
+  Layout,
+  Transaction,
+  Transactions,
+} from "pages";
 
 const queryClient = new QueryClient();
 
@@ -32,6 +40,9 @@ ReactDOM.render(
                 <Route path="transactions">
                   <Route index element={<Transactions />} />
                   <Route path=":hash" element={<Transaction />} />
+                </Route>
+                <Route path="addresses">
+                  <Route path=":address" element={<Address />} />
                 </Route>
               </Route>
             </Routes>

--- a/client/src/pages/address.tsx
+++ b/client/src/pages/address.tsx
@@ -12,34 +12,20 @@ import {
   Tr,
 } from "@liftedinit/ui";
 import { useQuery } from "@tanstack/react-query";
-import { ReactNode, useContext } from "react";
+import { useContext } from "react";
 import { Link, useParams } from "react-router-dom";
 
-import { getNeighborhoodBlock, NeighborhoodContext } from "api";
+import { getNeighborhoodAddress, NeighborhoodContext } from "api";
 import { TransactionList } from "ui";
-import { ago } from "utils";
 
-export function Block() {
+export function Address() {
   const { id } = useContext(NeighborhoodContext);
-  const { hash } = useParams();
+  const { address } = useParams();
 
   const { data, error, isLoading } = useQuery(
-    ["neighborhoods", id, "blocks", hash],
-    getNeighborhoodBlock(id, hash as string),
+    ["neighborhoods", id, "addresses", address],
+    getNeighborhoodAddress(id, address as string),
   );
-
-  let block: { [key: string]: ReactNode } = data
-    ? {
-        Hash: <Code>{data.blockHash}</Code>,
-        Height: data.height.toLocaleString(),
-        Time: (
-          <Text>
-            {ago(new Date(data.dateTime))} (
-            <Code>{new Date(data.dateTime).toISOString()}</Code>)
-          </Text>
-        ),
-      }
-    : {};
 
   return (
     <Box my={6}>
@@ -47,7 +33,7 @@ export function Block() {
         <Text as={Link} color="brand.teal.500" to="/">
           Home
         </Text>{" "}
-        / Block Details
+        / Address Details
       </Heading>
       <Box bg="white" my={6} p={6}>
         {isLoading ? (
@@ -57,14 +43,14 @@ export function Block() {
         ) : (
           <Table>
             <Tbody>
-              {Object.entries(block).map(([key, value]) => (
-                <Tr>
-                  <Td>
-                    <b>{key}</b>
-                  </Td>
-                  <Td>{value}</Td>
-                </Tr>
-              ))}
+              <Tr>
+                <Td>
+                  <b>Address</b>
+                </Td>
+                <Td>
+                  <Code>{address}</Code>
+                </Td>
+              </Tr>
             </Tbody>
           </Table>
         )}

--- a/client/src/pages/index.ts
+++ b/client/src/pages/index.ts
@@ -1,3 +1,4 @@
+export * from "./address";
 export * from "./block";
 export * from "./blocks";
 export * from "./home";

--- a/client/src/pages/transaction.tsx
+++ b/client/src/pages/transaction.tsx
@@ -61,8 +61,20 @@ export function Transaction() {
     const token = knownTokens.find((t) => t.address === data.argument.symbol);
     txn = {
       ...txn,
-      From: <Code>{data.argument.from}</Code>,
-      To: <Code>{data.argument.to}</Code>,
+      From: (
+        <Link to={`/addresses/${data.argument.from}`}>
+          <Text color="brand.teal.500">
+            <pre>{data.argument.from}</pre>
+          </Text>
+        </Link>
+      ),
+      To: (
+        <Link to={`/addresses/${data.argument.to}`}>
+          <Text color="brand.teal.500">
+            <pre>{data.argument.to}</pre>
+          </Text>
+        </Link>
+      ),
       Amount: token
         ? `${(data.argument.amount / 10 ** token.precision).toLocaleString()} ${
             token.ticker

--- a/client/src/ui/search.tsx
+++ b/client/src/ui/search.tsx
@@ -12,7 +12,7 @@ import { NavigateFunction, useNavigate } from "react-router-dom";
 const validTerms = [
   { path: "blocks", regex: /^\d+$/ },
   { path: "transactions", regex: /^[0-9a-f]{64}$/ },
-  { path: "address", regex: /^m[0-9a-zA-Z]{49,54}$/ },
+  { path: "addresses", regex: /^m[0-9a-zA-Z]{49,54}$/ },
 ];
 
 function isValid(term: string) {

--- a/client/src/ui/txn-list.tsx
+++ b/client/src/ui/txn-list.tsx
@@ -1,7 +1,6 @@
 import {
   Box,
   Center,
-  Code,
   Flex,
   Heading,
   Spacer,
@@ -80,7 +79,7 @@ export function TransactionList({
                 <Td>
                   <Link to={`/transactions/${txn.hash}`}>
                     <Text color="brand.teal.500">
-                      <Code>{abbr(txn.hash)}</Code>
+                      <pre>{abbr(txn.hash)}</pre>
                     </Text>
                   </Link>
                 </Td>


### PR DESCRIPTION
**Screenshot**

<img width="1392" alt="Screenshot 2023-04-03 at 3 53 05 PM" src="https://user-images.githubusercontent.com/405258/229643923-9efb4f97-5b87-4220-b1af-6a4682dff4c9.png">

Also working:

- [x] Search result redirects to Address page
- [x] Details for `from` and `to` in transactions link to Address page

Anything else you'd want to see on this page, @tysloan ?