### PR TITLE
fix: Reset active neighborhood if ID is missing

### DIFF
--- a/client/src/pages/layout/selector.tsx
+++ b/client/src/pages/layout/selector.tsx
@@ -28,8 +28,11 @@ export function NeighborhoodSelector() {
   }
 
   const neighborhoods: Neighborhood[] = data;
-  const activeIndex = neighborhoods.findIndex((n) => n.id === id);
-  const active = neighborhoods[activeIndex === -1 ? 0 : activeIndex];
+  const active = neighborhoods.filter((n) => n.id === id)[0];
+  if (!active) {
+    setId(neighborhoods[0].id);
+    return <Spinner />;
+  }
 
   return (
     <Menu>


### PR DESCRIPTION
The production database no longer has a neighborhood with `id` of 1, which is the default. This PR resets the active neighborhood to the first one in the `neighborhoods` response when that occurs (instead of timing out).