### PR TITLE
fix: Ignore unknown methods

### DIFF
--- a/client/src/pages/transaction/transaction.tsx
+++ b/client/src/pages/transaction/transaction.tsx
@@ -58,7 +58,7 @@ export function Transaction() {
     : {};
 
   // If we have details for the method type, add them
-  if (data?.argument) {
+  if (data?.argument && methodDetails[data.method]) {
     txn = { ...txn, ...methodDetails[data.method](data) };
   }
 


### PR DESCRIPTION
Prod currently barfs when a transaction has details but not a component to display them.