### PR TITLE
fix: Show amounts for mint/burn transactions

### DIFF
--- a/server/src/utils/protocol/attributes/tokens/tokens.burn.ts
+++ b/server/src/utils/protocol/attributes/tokens/tokens.burn.ts
@@ -24,7 +24,7 @@ export class TokensBurnAnalyzer extends Analyzer<ArgumentT, ResultT, EventT> {
   parseArgs(sender: Address, payload: Map<any, any>) {
     return {
       symbol: parseAddress(payload.get(0)).toString(),
-      amounts: parseTokenHolderMap(payload.get(2)),
+      amounts: parseTokenHolderMap(payload.get(1)),
       memo: parseMemo(payload.get(2), true),
     };
   }

--- a/server/src/utils/protocol/attributes/tokens/tokens.mint.ts
+++ b/server/src/utils/protocol/attributes/tokens/tokens.mint.ts
@@ -24,7 +24,7 @@ export class TokensMintAnalyzer extends Analyzer<ArgumentT, ResultT, EventT> {
   parseArgs(sender: Address, payload: Map<any, any>) {
     return {
       symbol: parseAddress(payload.get(0)).toString(),
-      amounts: parseTokenHolderMap(payload.get(2)),
+      amounts: parseTokenHolderMap(payload.get(1)),
       memo: parseMemo(payload.get(2), true),
     };
   }


### PR DESCRIPTION
From the spec:
```
tokens.mint@param = {
    ; The symbol of the token to mint.
    0 => ledger-symbol,

    ; Addresses and amounts to give to.
    1 => ledger-tokens-address-map,

    ; A memo about this event.
    ? 2 => memo,
}
```
```
ledger-tokens-event-info-mint = {
    0 => ledger-tokens-event-type-mint,
    1 => ledger-symbol,
    2 => ledger-tokens-address-map,
    ? 3 => memo,
}
```

My guess is the keys for commands and events got a bit mixed up.

Closes liftedinit/talib#246