### PR TITLE
bugfix: Removing index from metrics route

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -47,10 +47,10 @@ ReactDOM.render(
                   <Route path=":address" element={<Address />} />
                 </Route>
               </Route>
-                <Route path="metrics" index element={
-                  <WideLayout>
-                    <Metrics />
-                  </WideLayout>
+              <Route path="metrics" element={
+                <WideLayout>
+                  <Metrics />
+                </WideLayout>
                 } 
               >
               </Route>


### PR DESCRIPTION
## Description

A build failure caused an error with the index prop being set on the metric route but not being nested within the outlet context. I removed the index prop. 

## Related Issue

(https://github.com/liftedinit/operations/issues/90)

Fixes # (issue)

## Testing

Tested fix locally in client build

## Breaking Changes (if applicable)

None

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the CONTRIBUTING guidelines for this project.
- [x] I have added or updated tests and they pass.
- [x] I have added or updated documentation and it is accurate.
- [x] I have noted any breaking changes in this module or downstream modules.
