### PR TITLE
fix: Transaction list block height links

### DIFF
--- a/client/src/ui/txn-list.tsx
+++ b/client/src/ui/txn-list.tsx
@@ -95,7 +95,7 @@ export function TransactionList({
                   </Tag>
                 </Td>
                 <Td>
-                  <Link to={`/blocks/${txn.blockHash}`}>
+                  <Link to={`/blocks/${txn.blockHeight}`}>
                     <Text color="brand.teal.500">
                       {txn.blockHeight.toLocaleString()}
                     </Text>


### PR DESCRIPTION
Setting block height link to height rather than hash for query speed improvement. API response times are slow in querying by block hash but height is an indexed column so returns much faster. 

Fixes # (issue)

## Testing

Tested locally against a clone of prod. 

## Breaking Changes (if applicable)

None

## Screenshots (if applicable)

## Checklist:

- [ ] I have read and followed the CONTRIBUTING guidelines for this project.
- [ ] I have added or updated tests and they pass.
- [ ] I have added or updated documentation and it is accurate.
- [ ] I have noted any breaking changes in this module or downstream modules.
