### PR TITLE
Feat/gpu stats

### DIFF
--- a/client/src/pages/layout/navbar.tsx
+++ b/client/src/pages/layout/navbar.tsx
@@ -14,7 +14,7 @@ import { useBgColor } from "utils";
 import { NeighborhoodSelector } from "./selector";
 
 const navItems = [
-  { label: "Talib", link: "/" },
+  { label: "Blocks", link: "/" },
   { label: "Metrics", link: "/metrics"},
   { label: "Map", link: "/map" },
 ];

--- a/client/src/pages/metrics/metrics.tsx
+++ b/client/src/pages/metrics/metrics.tsx
@@ -3,7 +3,7 @@ import { Box, Heading, Center, Grid, GridItem, useMediaQuery } from "@liftedinit
 import { MetricNav } from "ui";
 import { NetworkMetrics } from "./networkMetrics";
 import { MdMemory, MdStorage, MdDns} from "react-icons/md";
-import { FaHive, FaNetworkWired, FaFile, FaServer, FaGhost } from "react-icons/fa6"
+import { FaHive, FaNetworkWired, FaFile, FaServer, FaGhost, FaRobot } from "react-icons/fa6"
 import { debounce } from 'lodash';
 
 const navItems = [
@@ -11,11 +11,11 @@ const navItems = [
   { label: "Nodes", section: "nodes", icon: FaServer },
   { label: "Web", section: "web", icon: MdDns },
   { label: "Hosting", section: "hosting", icon: FaGhost },
+  { label: "AI", section: "ai", icon: FaRobot },
   { label: "Storage", section: "storage", icon: MdStorage },
   { label: "Memory", section: "memory", icon: MdMemory },
   { label: "Network", section: "network", icon: FaNetworkWired },
   { label: "Object Storage", section: "object-storage", icon: FaFile },
-  // { label: "AI", section: "ai", icon: MdRobot },
 ];
 
 export function Metrics() {

--- a/client/src/pages/metrics/networkMetrics.tsx
+++ b/client/src/pages/metrics/networkMetrics.tsx
@@ -63,6 +63,21 @@ export function NetworkMetrics() {
           <MetricChart label="Total Web Requests" type="area" metric="totalwebrequests" transform="sumtotal" from={"now-60d"} to={"now"} fixedDecimals={0} ytitle="Requests" />
         </Box>
       </SimpleGrid>
+      <Heading as='h4' size='md' py="5" pl="5" >GPU</Heading>
+      <SimpleGrid id="ai" columns={{ base: 1, sm: 1, md: 2, lg: 3 }} gap="6" mt={2}>
+        <Box backgroundColor="transparent">
+          <MetricStat label="Total GPUs" metric="totalgpus" from={"now-1d"} to={"now"} fixedDecimals={5} unit="GPUs" />
+          <MetricChart label="Total GPUs" type="area" metric="totalgpus" from={"now-60d"} to={"now"} fixedDecimals={2}  ytitle="GPUs" />
+        </Box>
+        <Box backgroundColor="transparent">
+          <MetricStat label="Total Nvidia GPUs" metric="totalnvidiagpus" from={"now-1d"} to={"now"} fixedDecimals={5} unit="GPUs" />
+          <MetricChart label="Total Nvidia GPUs" type="area" metric="totalnvidiagpus" from={"now-60d"} to={"now"} fixedDecimals={2}  ytitle="GPUs" />
+        </Box>
+        <Box backgroundColor="transparent">
+          <MetricStat label="Total AMD GPUs" metric="totalamdgpus" from={"now-1d"} to={"now"} fixedDecimals={5} unit="GPUs" />
+          <MetricChart label="Total AMD GPUs" type="area" metric="totalamdgpus" from={"now-60d"} to={"now"} fixedDecimals={2}  ytitle="GPUs" />
+        </Box>
+      </SimpleGrid>
       <Heading as='h4' size='md' py="5" pl="5" >Disk</Heading>
       <SimpleGrid id="storage" columns={{ base: 1, sm: 1, md: 2, lg: 3 }} gap="6" mt={2}>
         <Box backgroundColor="transparent">


### PR DESCRIPTION
Adding an AI section to the metrics page.

## Description

- Enabled AI section in the sidebar menu 
- Added AI section with GPU sounds to the network metrics page
- Renamed the Talib menu item to Blocks for clarity. People don't know what a Talib is. 

Fixes # (issue)

## Testing

Tested locally against a clone of the production database. 

## Breaking Changes (if applicable)

None 

## Screenshots (if applicable)
![image](https://github.com/liftedinit/talib/assets/3028410/17755fd7-fa0e-4d59-98c3-aef84db04fe4)


## Checklist:

- [ ] I have read and followed the CONTRIBUTING guidelines for this project.
- [ ] I have added or updated tests and they pass.
- [ ] I have added or updated documentation and it is accurate.
- [ ] I have noted any breaking changes in this module or downstream modules.
