### PR TITLE
Feat: Add memo field to transaction details

### DIFF
--- a/client/src/pages/transaction/details.tsx
+++ b/client/src/pages/transaction/details.tsx
@@ -48,5 +48,21 @@ export function details(data: any) {
     txn = { ...txn, ...detailFn(data) };
   }
 
+  if (data.argument.memo) {
+    txn = {
+      ...txn,
+      Memo: (
+        <Text>
+          {data.argument.memo.map((m: string) => (
+          <>
+            <Code marginTop={2}>{m}</Code>
+            <br />
+          </>
+          ))}
+        </Text>
+      ),
+    };
+  }
+
   return txn;
 }

--- a/server/src/services/scheduler/neighborhood-updater/updater.ts
+++ b/server/src/services/scheduler/neighborhood-updater/updater.ts
@@ -199,7 +199,7 @@ export class NeighborhoodUpdater {
       await this.updateNeighborhoodMissingEvents(n);
     } catch (e) {
       this.logger.log(
-        `Error happened while updating neighborhood blocks for neighborhood:\n${e.stack}`,
+        `Error happened while updating neighborhood blocks for neighborhood ${n.id} ${n.name}:\n${e.stack}`,
       );
     }
 


### PR DESCRIPTION
Display memo field on transaction details page. 

## Description

- Added memo field to transaction details page if present in transaction data. 
- Added more detail to error logger for neighborhood updater, neighborhood name and ID. 

## Testing

- Locally against a clone of prod data. 

## Breaking Changes (if applicable)
 
- None

## Screenshots (if applicable)
![image](https://github.com/liftedinit/talib/assets/3028410/c7359330-e7d5-4434-bfa4-85ac11e721b0)


## Checklist:

- [ ] I have read and followed the CONTRIBUTING guidelines for this project.
- [ ] I have added or updated tests and they pass.
- [ ] I have added or updated documentation and it is accurate.
- [ ] I have noted any breaking changes in this module or downstream modules.
