### PR TITLE
feat: add pagination to addresses

### DIFF
--- a/client/src/api/neighborhood-provider.tsx
+++ b/client/src/api/neighborhood-provider.tsx
@@ -30,7 +30,7 @@ export function NeighborhoodProvider({ children }: { children: ReactNode }) {
 
   const tokensQuery = useQuery(
     ["neighborhoods", id, "tokens"],
-    getNeighborhoodTokens(id),
+    getNeighborhoodTokens(id, {page: 1, limit: 100}),
   );
 
   const { data, isError, isSuccess} = tokensQuery;

--- a/client/src/api/queries.ts
+++ b/client/src/api/queries.ts
@@ -37,8 +37,12 @@ export function getNeighborhoodTransaction(id: number, hash: string) {
   return get(`neighborhoods/${id}/transactions/${hash}`);
 }
 
-export function getNeighborhoodAddress(id: number, address: string) {
-  return get(`neighborhoods/${id}/addresses/${address}`);
+export function getNeighborhoodAddress(
+  id: number, 
+  address: string,
+  { page = PAGE, limit = LIMIT } = {}
+) {
+  return get(`neighborhoods/${id}/addresses/${address}`, { page, limit });
 }
 
 export function getNeighborhoodMigrations(

--- a/client/src/pages/address.tsx
+++ b/client/src/pages/address.tsx
@@ -1,24 +1,29 @@
 import { Box, Heading, Text } from "@liftedinit/ui";
 import { useQuery } from "@tanstack/react-query";
-import { useContext } from "react";
+import { useContext, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 
 import { getNeighborhoodAddress, NeighborhoodContext } from "api";
-import { ObjectTable, QueryBox, TransactionList } from "ui";
+import { ObjectTable, QueryBox, TransactionList, Pager } from "ui";
 
 import { useBgColor } from "utils";
 
 export function Address() {
   const { id } = useContext(NeighborhoodContext);
   const { address } = useParams();
-
+  const [page, setPage] = useState(1);
   const query = useQuery(
-    ["neighborhoods", id, "addresses", address],
-    getNeighborhoodAddress(id, address as string),
+    ["neighborhoods", id, "addresses", address, page],
+    getNeighborhoodAddress(id, address as string, { page }),
   );
   const { data, error, isLoading } = query;
 
   const bg = useBgColor();
+
+  console.log(`data: ${JSON.stringify(data)}`);
+  console.log(`error: ${error}`);
+  console.log(`totalPages: ${JSON.stringify(data?.transactions.totalPages)}`);
+  console.log(`page: ${page}`);
 
   return (
     <Box my={6} bg={bg} p={6}>
@@ -31,15 +36,17 @@ export function Address() {
       <QueryBox query={query}>
         <ObjectTable obj={{ Address: address }} />
       </QueryBox>
-      {data?.transactions.length ? (
+      {data?.transactions.items.length ? (
         <TransactionList
-          txns={data.transactions}
+          txns={data?.transactions.items}
           error={error as Error}
           isLoading={isLoading}
         />
       ) : (
-        ""
+          ""
       )}
+
+      <Pager page={page} setPage={setPage} totalPages={data?.transactions.meta.totalPages} />
     </Box>
   );
 }

--- a/client/src/pages/transaction/ledger-send.tsx
+++ b/client/src/pages/transaction/ledger-send.tsx
@@ -24,9 +24,9 @@ export function useLedgerSend(data: any) {
         {data.argument.to}
       </Code>
     ),
-    Amount: `${(
+    Amount: `${parseFloat((
       data.argument.amount /
       10 ** token.precision
-    ).toLocaleString()} ${token.symbol}`,
+    ).toFixed(token.precision).toLocaleString())} ${token.symbol}`,
   };
 }

--- a/client/src/pages/transaction/tokens-mint-burn.tsx
+++ b/client/src/pages/transaction/tokens-mint-burn.tsx
@@ -4,16 +4,17 @@ import { useFindToken } from "./tokens";
 
 export function useTokensMintBurn(data: any) {
   const token = useFindToken(data.argument.symbol);
+
   return {
     Token: (
       <Code as={Link} to={`/addresses/${token.address}`} color="brand.teal.500">
-        {data.argument.symbol}
+        {data.argument.symbol} 
       </Code>
     ),
     Amounts: (
       <Table variant="unstyled">
         <Tbody>
-          {Object.entries(data.argument.amounts).map(([address, amount]) => (
+        {Object.entries(data.argument.amounts).map(([address, amount]) => (
             <Tr mt="5px" mb="5px">
               <Td pt="5px" pb="5px" pl="0" ps="0">
                 <Code
@@ -28,8 +29,7 @@ export function useTokensMintBurn(data: any) {
                 {(
                   parseInt(amount as string) /
                   10 ** token.precision
-                ).toLocaleString()}{" "}
-                {token.symbol}
+                ).toLocaleString()} {token.symbol}
               </Td>
             </Tr>
           ))}

--- a/client/src/pages/transaction/tokens.tsx
+++ b/client/src/pages/transaction/tokens.tsx
@@ -6,7 +6,6 @@ interface token  {
   symbol: string,
   address: string,
   precision: number
-
 }
 
 export const MFX_TOKEN = {
@@ -28,12 +27,14 @@ export function useFindToken(address: string) {
 
   let KNOWN_TOKENS: token[] = context.tokens
 
+  console.log(`context.tokens: ${JSON.stringify(context.tokens)}`);
+
   // Check if there are tokens otherwise configure default to MFX 
   if (KNOWN_TOKENS === undefined || KNOWN_TOKENS.length === 0) {
     KNOWN_TOKENS = [MFX_TOKEN];
-} else {
+  } else {
     KNOWN_TOKENS = context.tokens;
-}
+  }
 
   return KNOWN_TOKENS?.find((t) => t.address === address) ?? UNKNOWN_TOKEN;
 }

--- a/server/src/neighborhoods/addresses/addresses.controller.ts
+++ b/server/src/neighborhoods/addresses/addresses.controller.ts
@@ -15,6 +15,7 @@ import { EventDto } from "../../dto/event.dto";
 import { TransactionDto } from "../../dto/transaction.dto";
 import { ParseAddressPipe } from "../../utils/pipes";
 import { AddressesService } from "./addresses.service";
+import { PaginatedAddressDto } from "./addresses.service";
 
 const maxLimit = 1000;
 
@@ -44,8 +45,10 @@ export class AddressesController {
   async findOne(
     @Param("nid", ParseIntPipe) nid: number,
     @Param("address", ParseAddressPipe) address: Address,
-  ): Promise<AddressDto> {
-    const a = await this.address.findOne(nid, address, { page: 1, limit: 100 });
+    @Query("page", new DefaultValuePipe(1), ParseIntPipe) page = 1,
+    @Query("limit", new DefaultValuePipe(100), ParseIntPipe) limit = 100,
+  ): Promise<PaginatedAddressDto> {
+    const a = await this.address.findOne(nid, address, { page, limit });
 
     if (!a) {
       throw new NotFoundException();

--- a/server/src/neighborhoods/addresses/addresses.service.ts
+++ b/server/src/neighborhoods/addresses/addresses.service.ts
@@ -13,9 +13,24 @@ import { Event } from "../../database/entities/event.entity";
 import { TransactionDetails } from "../../database/entities/transaction-details.entity";
 import { Transaction } from "../../database/entities/transaction.entity";
 import { AddressDto } from "../../dto/address.dto";
+import { TransactionDto } from "../../dto/transaction.dto";
+import { EventDto } from "../../dto/event.dto";
 import { NetworkService } from "../../services/network.service";
 import { TxAnalyzerService } from "../../services/scheduler/tx-analyzer.service";
 import { EventsService } from "../events/events.service";
+
+export interface PaginatedAddressDto {
+  address: string;
+  transactions: {
+    items: TransactionDto[];
+    meta: any;
+  };
+  events: {
+    items: EventDto[];
+    meta: any;
+  };
+}
+
 
 @Injectable()
 export class AddressesService {
@@ -81,15 +96,21 @@ export class AddressesService {
     nid: number,
     address: Address,
     txOptions: IPaginationOptions,
-    evOptions = txOptions,
-  ): Promise<AddressDto> {
+    evOptions: IPaginationOptions = txOptions,
+  ): Promise<PaginatedAddressDto> {
     const transactions = await this.findTransactions(nid, address, txOptions);
     const events = await this.findEvents(nid, address, evOptions);
-
+  
     return {
       address: address.toString(),
-      transactions: transactions.items.map((t) => t.intoDto()),
-      events: events.items.map((e) => e.intoDto()),
+      transactions: {
+        items: transactions.items.map((t) => t.intoDto()),
+        meta: transactions.meta,
+      },
+      events: {
+        items: events.items.map((e) => e.intoDto() as EventDto),
+        meta: events.meta,
+      },
     };
   }
 

--- a/server/src/neighborhoods/events/events.service.ts
+++ b/server/src/neighborhoods/events/events.service.ts
@@ -45,7 +45,16 @@ export class EventsService {
   }
 
   public async save(entities: EventEntity[]): Promise<void> {
-    await this.eventRepository.save(entities);
+    await Promise.all(
+      entities.map(async (entity) => {
+        try {
+          this.logger.debug(`Saving event: ${JSON.stringify(entity)}`);
+          await this.eventRepository.save(entity);
+        } catch (error) {
+          this.logger.error(`Error occurred while saving event: ${JSON.stringify(entity)}, ${error}`);
+        }
+      })
+    );
   }
 
   async findWithAddress(

--- a/server/src/neighborhoods/events/events.service.ts
+++ b/server/src/neighborhoods/events/events.service.ts
@@ -48,10 +48,9 @@ export class EventsService {
     await Promise.all(
       entities.map(async (entity) => {
         try {
-          this.logger.debug(`Saving event: ${JSON.stringify(entity)}`);
           await this.eventRepository.save(entity);
         } catch (error) {
-          this.logger.error(`Error occurred while saving event: ${JSON.stringify(entity)}, ${error}`);
+          this.logger.error(`Error occurred while saving event: ${JSON.stringify(entity)}, ${error}, eventId: ${JSON.stringify(entity.eventId)}`);
         }
       })
     );

--- a/server/src/neighborhoods/migrations/migrations.service.ts
+++ b/server/src/neighborhoods/migrations/migrations.service.ts
@@ -61,7 +61,9 @@ export class MigrationsService {
       .createQueryBuilder("m")
       .select(["m"])
       .innerJoin("m.transaction", "t")
-      .innerJoin(Block, 'b', 'b.id = t.blockId AND b.neighborhoodId = :neighborhoodId', { neighborhoodId: neighborhoodId });
+      .innerJoin(Block, 'b', 'b.id = t.blockId AND b.neighborhoodId = :neighborhoodId', { neighborhoodId: neighborhoodId })
+      .orderBy("m.createdDate", "DESC");
+      
 
     if (status) {
       query = query.andWhere("m.status = :status", { status });

--- a/server/src/services/scheduler/neighborhood-updater/updater.ts
+++ b/server/src/services/scheduler/neighborhood-updater/updater.ts
@@ -60,7 +60,7 @@ export class NeighborhoodUpdater {
       // Lower bound on eventID exclusive.
       new Map([[3, new Map([[0, [1, latestEventId]]])]]),
     );
-    this.logger.debug(`Got ${events.events.length} events`);
+    this.logger.debug(`Got ${events.events.length} events for neighborhood ${neighborhood.name}`);
 
     await this.events.save(
       events.events.map((ev) => {

--- a/server/src/services/scheduler/neighborhood-updater/updater.ts
+++ b/server/src/services/scheduler/neighborhood-updater/updater.ts
@@ -60,6 +60,7 @@ export class NeighborhoodUpdater {
       // Lower bound on eventID exclusive.
       new Map([[3, new Map([[0, [1, latestEventId]]])]]),
     );
+    this.logger.debug(`Got ${events.events.length} events`);
 
     await this.events.save(
       events.events.map((ev) => {
@@ -77,21 +78,6 @@ export class NeighborhoodUpdater {
       }),
     );
 
-    console.log(
-      JSON.stringify(
-        events.events
-          .map((ev) => {
-            return {
-              ...ev,
-              id: bufferToHex(ev.id),
-              time: ev.time.toISOString(),
-            };
-          })
-          .filter((ev) => ev.info === null),
-        null,
-        2,
-      ),
-    );
   }
 
   private async updateNeighborhoodMissingTransactionDetails(


### PR DESCRIPTION
For addresses with larger numbers of transactions, we were missing pagination on the /addresses/[address] page in the UI. This branch adds pagination to the endpoint in the server and to the UI. 

## Description
- Added pagination and interface definition to address service function for findOne address. 
- Added pagination to addresses controller endpoint for one address. 
- Added pager component to UI for addresses page and added pagination meta to API query in frontend.
- Fixed migrations endpoint to display most recent migrations first
- Fixed tokens query to retrieve 100 tokens, which was limited to 25 and missing tokens from the alpha prod network.

## Related Issue

Fixes # (issue)
https://github.com/liftedinit/talib/issues/318 
https://github.com/liftedinit/talib/issues/320 
https://github.com/liftedinit/talib/issues/306 

## Testing
Tested locally against a clone of prod database.

## Breaking Changes (if applicable)

None

## Screenshots (if applicable)
Pager on Address transactions view
![image](https://github.com/user-attachments/assets/2ec1bb72-c922-4364-8939-f4e45ee1e91d)

Fix of precision on ledger-send: 

![image](https://github.com/user-attachments/assets/d507570c-a1ac-41a7-bd91-95110bf6a7c7)


## Checklist:

- [x] I have read and followed the CONTRIBUTING guidelines for this project.
- [ ] I have added or updated tests and they pass.
- [ ] I have added or updated documentation and it is accurate.
- [x] I have noted any breaking changes in this module or downstream modules.
