### PR TITLE
fix: transform select queries for the argument field

### DIFF
--- a/server/src/database/entities/transaction-details.entity.ts
+++ b/server/src/database/entities/transaction-details.entity.ts
@@ -39,7 +39,22 @@ export class TransactionDetails {
   })
   sender?: Address;
 
-  @Column({ type: "json", nullable: true })
+  @Column({
+    type: 'json',
+    nullable: true,
+    transformer: {
+      from: (value) => {
+        // Ensure amount is a string
+        if (value?.amount) {
+          value.amount = value.amount.toString();
+        }
+        return value;
+      },
+      to: (value) => {
+        return value;
+      },
+    },
+  })
   argument?: object;
 
   @Column({ type: "json", nullable: true })


### PR DESCRIPTION
Ensure amounts are always returned as string

## Description

- Added a transformer to the argument column in the transaction details table to ensure amounts are always returned as string for select queries. 

## Related Issue

## Testing

- Tested locally against a clone of prod

## Breaking Changes (if applicable)

## Screenshots (if applicable)

## Checklist:

- [ ] I have read and followed the CONTRIBUTING guidelines for this project.
- [ ] I have added or updated tests and they pass.
- [ ] I have added or updated documentation and it is accurate.
- [ ] I have noted any breaking changes in this module or downstream modules.
