### PR TITLE
fix: parse transactions from old attribute formats

### DIFF
--- a/client/src/pages/transaction/details.tsx
+++ b/client/src/pages/transaction/details.tsx
@@ -30,8 +30,9 @@ const methodDetails: {
 };
 
 export function details(data: any) {
-  const detailFn = methodDetails[data.method];
-  const prettyMethod = PrettyMethods[data.method] || "Unknown";
+  const method = data.method || data._method;
+  const detailFn = methodDetails[method];
+  const prettyMethod = PrettyMethods[method] || "Unknown";
 
   let txn: TableObject = {
     Type: (
@@ -39,7 +40,7 @@ export function details(data: any) {
         <Tag variant="outline" size="sm">
           {prettyMethod}
         </Tag>{" "}
-        (<Code>{data.method}</Code>)
+        (<Code>{method}</Code>)
       </Text>
     ),
   };
@@ -48,7 +49,7 @@ export function details(data: any) {
     txn = { ...txn, ...detailFn(data) };
   }
 
-  if (data.argument.memo) {
+  if (data.argument && data.argument.memo) {
     txn = {
       ...txn,
       Memo: (

--- a/client/src/pages/transaction/ledger-send.tsx
+++ b/client/src/pages/transaction/ledger-send.tsx
@@ -3,29 +3,48 @@ import { Link } from "react-router-dom";
 import { useFindToken } from "./tokens";
 
 export function useLedgerSend(data: any) {
-  const token = useFindToken(data.argument.symbol);
+  let symbol: string = "";
+  let from: string = "";
+  let to: string = "";
+  let amount: any = "";
+
+  if (!data.argument) {
+    if (data._method === "ledger.send") {
+      symbol = data.symbol;
+      from = data.from;
+      to = data.to;
+      amount = data.amount;
+    }
+  } else {  
+      symbol = data.argument.symbol;
+      from = data.argument.from;
+      to = data.argument.to;
+      amount = data.argument.amount;
+  }
+
+  const token = useFindToken(symbol);
 
   return {
     From: (
       <Code
         as={Link}
-        to={`/addresses/${data.argument.from}`}
+        to={`/addresses/${from}`}
         color="brand.teal.500"
       >
-        {data.argument.from}
+        {from}
       </Code>
     ),
     To: (
       <Code
         as={Link}
-        to={`/addresses/${data.argument.to}`}
+        to={`/addresses/${to}`}
         color="brand.teal.500"
       >
-        {data.argument.to}
+        {to}
       </Code>
     ),
     Amount: `${parseFloat((
-      data.argument.amount /
+      amount /
       10 ** token.precision
     ).toFixed(token.precision).toLocaleString())} ${token.symbol}`,
   };


### PR DESCRIPTION
## Description

- Set method to either format (method or _method) based on attribute structure for ledger.send
- Set symbol information based on attribute structure for ledger.send 

## Related Issue

<!-- Pull Requests should relate to an open Issue. -->
<!-- If this PR fixes a bug or introduces a new feature, please create an Issue first. -->

Fixes # (issue)

## Testing

- 

## Breaking Changes (if applicable)
None

## Screenshots (if applicable)
No changes to UI 

## Checklist:

- [ ] I have read and followed the CONTRIBUTING guidelines for this project.
- [ ] I have added or updated tests and they pass.
- [ ] I have added or updated documentation and it is accurate.
- [ ] I have noted any breaking changes in this module or downstream modules.
