### PR TITLE
fix: set stroke to straight on tokenomics section and fix ordering on…

### DIFF
--- a/client/src/pages/metrics/metrics.tsx
+++ b/client/src/pages/metrics/metrics.tsx
@@ -4,21 +4,22 @@ import { MetricNav } from "ui";
 import { NetworkMetrics } from "./networkMetrics";
 import { MdMemory, MdStorage, MdDns} from "react-icons/md";
 import { SiKubernetes } from "react-icons/si";
-import { FaHive, FaNetworkWired, FaFile, FaServer, FaGhost, FaRobot } from "react-icons/fa6"
+import { FaHive, FaNetworkWired, FaFile, FaServer, FaGhost, FaRobot, FaWallet } from "react-icons/fa6"
 import { debounce } from 'lodash';
 
 const navItems = [
-  { label: "Tokenomics", section: "tokenomics", icon: FaHive },
+  { label: "Tokenomics", section: "tokenomics", icon: FaWallet },
   { label: "Neighborhoods", section: "blockchain", icon: FaHive },
   { label: "Nodes", section: "nodes", icon: FaServer },
   { label: "Kubernetes", section: "kubernetes", icon: SiKubernetes },
   { label: "Web", section: "web", icon: MdDns },
   { label: "Hosting", section: "hosting", icon: FaGhost },
   { label: "AI", section: "ai", icon: FaRobot },
+  { label: "Network", section: "network", icon: FaNetworkWired },
   { label: "Storage", section: "storage", icon: MdStorage },
   { label: "Memory", section: "memory", icon: MdMemory },
   { label: "Object Storage", section: "object-storage", icon: FaFile },
-  { label: "Network", section: "network", icon: FaNetworkWired },
+
 ];
 
 export function Metrics() {

--- a/client/src/pages/metrics/networkMetrics.tsx
+++ b/client/src/pages/metrics/networkMetrics.tsx
@@ -10,7 +10,7 @@ export function NetworkMetrics() {
       <SimpleGrid id="tokenomics" columns={{ base: 1, sm: 1, md: 2, lg: 2 }} gap="6" mt={2}>
         <Box backgroundColor="transparent" >
           <MetricStat label="POWER : MFX Conversion Rate" metric="mfxpowerconversion" unit=": 1" fixedDecimals={2} />
-          <MetricChart label="POWER:MFX" type="area" metric="mfxpowerconversion" from={"now-180d"} to={"now"} fixedDecimals={2} smoothed={false}  height={["200px", "300px", "400px"]}/>
+          <MetricChart label="POWER:MFX" type="area" metric="mfxpowerconversion" from={"now-180d"} to={"now"} fixedDecimals={2} smoothed={false} stroke="straight" height={["200px", "300px", "400px"]}/>
         </Box>
         <Box backgroundColor="transparent" h={["100px", "200px", "300px"]} >
           <MetricStat label="Total Tokens" metric="totaltokens" />


### PR DESCRIPTION
This pull request includes updates to the `metrics` page in the client application, focusing on the navigation items and the display of the network metrics.

Changes to navigation items:

* [`client/src/pages/metrics/metrics.tsx`](diffhunk://#diff-9cf7c5cb8a66ef16a056700b60c1e8ba1f40a1f011ce861d1d33a117d86c110fL7-R22): Added `FaWallet` icon to the import statement and updated the "Tokenomics" section to use the `FaWallet` icon instead of `FaHive`. Additionally, the "Network" section was moved to a different position in the `navItems` array.

Changes to network metrics display:

* [`client/src/pages/metrics/networkMetrics.tsx`](diffhunk://#diff-0076adf4832148ef179117a277e4c1f141b253b4705c8341fa5ebf87b310353aL13-R13): Modified the `MetricChart` component for the "POWER:MFX" chart to include the `stroke="straight"` property, which changes the chart's stroke style.… sidebar nav

## Testing
- Local tested 

## Breaking Changes (if applicable)

None

## Screenshots (if applicable)

## Checklist:

- [ ] I have read and followed the CONTRIBUTING guidelines for this project.
- [ ] I have added or updated tests and they pass.
- [ ] I have added or updated documentation and it is accurate.
- [ ] I have noted any breaking changes in this module or downstream modules.
