### PR TITLE
fix: removed smoothing on total processes chart to fix render issue

### DIFF
--- a/client/src/pages/metrics/networkMetrics.tsx
+++ b/client/src/pages/metrics/networkMetrics.tsx
@@ -44,7 +44,7 @@ export function NetworkMetrics() {
         </Box>
         <Box backgroundColor="transparent">
           <MetricStat label="Total Processes" metric="totalprocesses" from={"now-1d"} to={"now"} />
-          <MetricChart label="Total Processes" type="area" metric="totalprocesses" from={"now-90d"} to={"now"} fixedDecimals={0} ytitle="Processes" stroke="monotoneCubic" smoothed={true} />
+          <MetricChart label="Total Processes" type="area" metric="totalprocesses" from={"now-90d"} to={"now"} fixedDecimals={0} ytitle="Processes" />
         </Box>
       </SimpleGrid>
       <Heading as='h4' size='md' py="5" pl="5" >Kubernetes</Heading>


### PR DESCRIPTION
This pull request includes a small change to the `NetworkMetrics` component in the `client/src/pages/metrics/networkMetrics.tsx` file. The change removes the `stroke` and `smoothed` properties from the `MetricChart` component. 

* [`client/src/pages/metrics/networkMetrics.tsx`](diffhunk://#diff-0076adf4832148ef179117a277e4c1f141b253b4705c8341fa5ebf87b310353aL47-R47): Removed the `stroke` and `smoothed` properties from the `MetricChart` component in the `NetworkMetrics` function.<!-- Provide a general summary of changes in the title above. -->

## Testing

Local testing

## Breaking Changes (if applicable)

None

## Screenshots (if applicable)

## Checklist:

- [ ] I have read and followed the CONTRIBUTING guidelines for this project.
- [ ] I have added or updated tests and they pass.
- [ ] I have added or updated documentation and it is accurate.
- [ ] I have noted any breaking changes in this module or downstream modules.
