### PR TITLE
Burned MFX: headline figures + accurate zero-filled series

### DIFF
--- a/client/src/ui/burned-mfx-cumulative-chart.spec.tsx
+++ b/client/src/ui/burned-mfx-cumulative-chart.spec.tsx
@@ -49,4 +49,17 @@ describe("BurnedMfxCumulativeChart", () => {
     const series = JSON.parse(apex.getAttribute("data-series")!);
     expect(series).toEqual([{ name: "Burned MFX", data: [1, 3] }]);
   });
+
+  it("shows the cumulative total (the final series value) under the title", async () => {
+    vi.mocked(getBurnedMfxSeries).mockReturnValueOnce(
+      async () => ({
+        timestamps: [new Date("2026-01-01"), new Date("2026-01-02")],
+        data: ["1000000000", "5000000000"],
+      }),
+    );
+
+    render(wrap(<BurnedMfxCumulativeChart nid={1} />));
+
+    expect(await screen.findByText(/^5\s*MFX$/)).toBeInTheDocument();
+  });
 });

--- a/client/src/ui/burned-mfx-cumulative-chart.tsx
+++ b/client/src/ui/burned-mfx-cumulative-chart.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Chart from "react-apexcharts";
 import { useQuery } from "@tanstack/react-query";
-import { Box, Center, Heading, Spinner, Text } from "@liftedinit/ui";
+import { Box, Center, Heading, Spinner, Stat, StatNumber, Text } from "@liftedinit/ui";
 import { getBurnedMfxSeries } from "api";
 import { useBgColor, LONG_STALE_INTERVAL, LONG_REFRESH_INTERVAL } from "utils";
 
@@ -65,6 +65,11 @@ export function BurnedMfxCumulativeChart({ nid }: Props) {
     t instanceof Date ? t.toISOString() : t,
   );
 
+  // The series is cumulative, so the final point is the total burned to date.
+  const totalMfx = seriesMfx[seriesMfx.length - 1].toLocaleString(undefined, {
+    maximumFractionDigits: 0,
+  });
+
   return (
     <Box
       p={4}
@@ -73,9 +78,12 @@ export function BurnedMfxCumulativeChart({ nid }: Props) {
       display="flex"
       flexDirection="column"
     >
-      <Heading as="h5" size="sm" mb={2}>
+      <Heading as="h5" size="sm" mb={1}>
         Cumulative Burned MFX
       </Heading>
+      <Stat flex="0 0 auto" mb={2}>
+        <StatNumber>{totalMfx} MFX</StatNumber>
+      </Stat>
       <Box flex="1" minH={0}>
       <Chart
         height="100%"

--- a/client/src/ui/burned-mfx-rate-chart.spec.tsx
+++ b/client/src/ui/burned-mfx-rate-chart.spec.tsx
@@ -47,6 +47,15 @@ describe("BurnedMfxRateChart", () => {
     expect(series[0].data).toEqual([2, 3, 4]);
   });
 
+  it("shows the average rate (per selected unit) under the title", async () => {
+    vi.mocked(getBurnedMfxSeries).mockReturnValueOnce(async () => fourDays);
+
+    render(wrap(<BurnedMfxRateChart nid={1} />));
+
+    // Day-over-day MFX diffs are 2, 3, 4 → average 3 MFX per day.
+    expect(await screen.findByText(/3\s*MFX\s*\/\s*day/i)).toBeInTheDocument();
+  });
+
   it("re-renders rates when the dropdown changes unit", async () => {
     vi.mocked(getBurnedMfxSeries).mockReturnValueOnce(async () => fourDays);
 

--- a/client/src/ui/burned-mfx-rate-chart.tsx
+++ b/client/src/ui/burned-mfx-rate-chart.tsx
@@ -1,11 +1,12 @@
 import React, { useMemo, useState } from "react";
 import Chart from "react-apexcharts";
 import { useQuery } from "@tanstack/react-query";
-import { Box, Center, Flex, Heading, Select, Spinner, Text } from "@liftedinit/ui";
+import { Box, Center, Flex, Heading, Select, Spinner, Stat, StatNumber, Text } from "@liftedinit/ui";
 import { getBurnedMfxSeries } from "api";
 import { useBgColor, LONG_STALE_INTERVAL, LONG_REFRESH_INTERVAL } from "utils";
 import {
   calculateRates,
+  calculateAverageRate,
   RATE_UNIT_LABELS,
   RATE_UNIT_OPTIONS,
   type CumulativePoint,
@@ -84,6 +85,17 @@ export function BurnedMfxRateChart({ nid }: Props) {
   const seriesMfx = rates.map((p) => Number(BigInt(p.value) / UMFX_PER_MFX));
   const categories = rates.map((p) => p.date.toISOString());
 
+  // Headline figure: the average burn rate over the windows, matching the
+  // manifest-dashboard burn-rate card. "Per Day" -> "day" for the unit suffix.
+  const unitLabel = RATE_UNIT_LABELS[rateUnit].replace("Per ", "").toLowerCase();
+  const avgRate =
+    rates.length > 0
+      ? `${(Number(calculateAverageRate(rates)) / Number(UMFX_PER_MFX)).toLocaleString(
+          undefined,
+          { maximumFractionDigits: 2 },
+        )} MFX / ${unitLabel}`
+      : "N/A";
+
   return (
     <Box
       p={4}
@@ -105,6 +117,9 @@ export function BurnedMfxRateChart({ nid }: Props) {
           ))}
         </Select>
       </Flex>
+      <Stat flex="0 0 auto" mb={2}>
+        <StatNumber>{avgRate}</StatNumber>
+      </Stat>
       <Box flex="1" minH={0}>
       <Chart
         height="100%"

--- a/client/src/utils/burn-rate.spec.ts
+++ b/client/src/utils/burn-rate.spec.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { calculateRates, type CumulativePoint, type RateUnit } from "./burn-rate";
+import {
+  calculateRates,
+  calculateAverageRate,
+  type CumulativePoint,
+  type RateUnit,
+} from "./burn-rate";
 
 const point = (date: string, value: string): CumulativePoint => ({
   date: new Date(date),
@@ -54,5 +59,21 @@ describe("calculateRates", () => {
     );
 
     expect(result).toEqual([]);
+  });
+});
+
+describe("calculateAverageRate", () => {
+  it("returns 0n for an empty series", () => {
+    expect(calculateAverageRate([])).toBe(0n);
+  });
+
+  it("averages the rate values (floored to whole uMFX)", () => {
+    const avg = calculateAverageRate([
+      point("2026-01-02", "150"),
+      point("2026-01-03", "150"),
+      point("2026-01-04", "300"),
+    ]);
+
+    expect(avg).toBe(200n); // (150 + 150 + 300) / 3
   });
 });

--- a/client/src/utils/burn-rate.ts
+++ b/client/src/utils/burn-rate.ts
@@ -71,3 +71,16 @@ export function calculateRates(
 
   return out;
 }
+
+/**
+ * Mean of a rate series' values, in uMFX. Returns 0n for an empty series.
+ * BigInt sum keeps it exact; the final divide floors a sub-uMFX remainder
+ * that is irrelevant for display. Mirrors manifest-dashboard's
+ * calculateAverage, which drives its burn-rate card's headline figure.
+ */
+export function calculateAverageRate(rates: CumulativePoint[]): bigint {
+  if (!rates || rates.length === 0) return 0n;
+
+  const sum = rates.reduce((acc, p) => acc + BigInt(p.value), 0n);
+  return sum / BigInt(rates.length);
+}

--- a/docs/plans/2026-05-26-burned-mfx-zero-fill-plan.md
+++ b/docs/plans/2026-05-26-burned-mfx-zero-fill-plan.md
@@ -1,0 +1,221 @@
+# Zero-fill the burned-MFX series — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `MigrationsService.getBurnedMfxSeries` emit a **dense daily** cumulative series — one point per UTC calendar day from the first migration day through today — instead of one point only on days that had a migration. The cumulative value is carried forward (0 increment on quiet days) so the client's windowed rate calculation (`calculateRates`) becomes correct with **no client change**.
+
+**Scope:** Server only. One method (`getBurnedMfxSeries`) and its unit test. The endpoint response shape (`{ timestamps, data }`), the controller, `SeriesEntity`, and both client charts are unchanged.
+
+**Spec:** `docs/specs/2026-05-26-burned-mfx-zero-fill-design.md` (Approved).
+
+**Why:** On neighborhood 1 the sparse series is 32 active days across 348 calendar days (mean gap 11.2 days). `calculateRates` assumes points are time-adjacent, so the headline per-day rate reads **111,916 MFX/day** vs. a true **~9,970 MFX/day**. A dense daily spine fixes the rate math at the source.
+
+---
+
+## File Map
+
+**Server (modified):**
+- `server/src/neighborhoods/migrations/migrations.service.ts` — replace **only** the SQL string inside `getBurnedMfxSeries` (lines ~81–106). The Token lookup, the missing-token early return + warn-once, the bytea→UTF-8 address decode, the `params` array, and the row→`{timestamps,data}` transform all stay exactly as-is.
+- `server/src/neighborhoods/migrations/migrations.service.spec.ts` — update the "emits SQL" / shape assertions to the new query; keep the transform, empty-token, and warn-once tests.
+
+**Nothing else changes.** No new files, no controller/module/DTO/client edits.
+
+---
+
+## Key facts established during planning (do not re-derive)
+
+- `migration."manifestDatetime"` is a `timestamp without time zone` holding **UTC wall-clock** (`migration.entity.ts:54`, nullable). The current query already uses `date_trunc('day', m."manifestDatetime")`, producing midnight `timestamp without time zone` values.
+- `SeriesEntity` is `{ data: number[] | string[]; timestamps: Date[] }` (`metrics.service.ts:15`). `cumulative` is `numeric` → returned as a **string** by the pg driver; the transform maps it straight through, so keep it a string.
+- The transform reads `r.timestamp` and `r.cumulative` by name (`migrations.service.ts:111–112`). The new query MUST keep those two output column aliases.
+- The new query's `timestamp` output stays `timestamp without time zone` (see "Output type" below), so pg-driver Date parsing is **identical to today** — no timezone-parsing regression risk.
+- Client `calculateRates` (`client/src/utils/burn-rate.ts`) is a two-pointer diff over the ASC series; with daily-adjacent points the `per_day` baseline becomes the immediately preceding day, so each rate point equals that day's burn. `calculateAverageRate` is the mean of those points. This is exactly why the dense spine fixes the headline number.
+
+---
+
+## Task 1: Replace the SQL in `getBurnedMfxSeries`
+
+**File:** `server/src/neighborhoods/migrations/migrations.service.ts`
+
+- [ ] **Step 1: Swap the query body.** Replace the template-literal SQL passed to `this.migrationRepository.manager.query(...)` with the dense-spine query below. Leave the `[neighborhoodId, mfxAddressStr]` params and everything around the call untouched.
+
+```sql
+WITH daily AS (                       -- per-day burn totals (aggregation UNCHANGED from current query)
+  SELECT
+    date_trunc('day', m."manifestDatetime") AS day,
+    SUM((COALESCE(
+      td.argument ->> 'amount',
+      td.argument -> 'transaction' -> 'argument' ->> 'amount'
+    ))::numeric) AS amount
+  FROM migration m
+  INNER JOIN transaction_details td ON td.id = m."detailsId"
+  INNER JOIN transaction t          ON t.id  = m."transactionId"
+  INNER JOIN block b                ON b.id  = t."blockId"
+                                     AND b."neighborhoodId" = $1
+  WHERE m."manifestDatetime" IS NOT NULL
+    AND COALESCE(
+      td.argument ->> 'symbol',
+      td.argument -> 'transaction' -> 'argument' ->> 'symbol'
+    ) = $2
+  GROUP BY date_trunc('day', m."manifestDatetime")
+),
+spine AS (                            -- every UTC day, first burn day -> today (UTC)
+  SELECT generate_series(
+           (SELECT min(day) FROM daily),
+           date_trunc('day', (now() AT TIME ZONE 'UTC')),
+           interval '1 day'
+         ) AS day
+)
+SELECT
+  spine.day AS timestamp,
+  SUM(COALESCE(daily.amount, 0)) OVER (ORDER BY spine.day) AS cumulative
+FROM spine
+LEFT JOIN daily ON daily.day = spine.day
+ORDER BY spine.day ASC
+```
+
+  Critical details the implementer MUST preserve:
+  - **Output aliases stay `timestamp` and `cumulative`** — the transform depends on them.
+  - **`COALESCE(daily.amount, 0)`** inside the window `SUM` is what carries the cumulative forward across zero-burn days. Do not drop the `COALESCE`.
+  - **`ORDER BY spine.day`** in the window frame — order by the *spine* column, not `daily.day` (which is NULL on filled days).
+  - **`$1` / `$2`** keep their current meaning (`neighborhoodId`, `mfxAddressStr`); param array is unchanged.
+  - Keep the two-shape `COALESCE(... ->> 'symbol' ...)` / `COALESCE(... ->> 'amount' ...)` JSON extraction verbatim — it covers both the direct `ledger.send` and the multisig-wrapped argument shapes.
+
+- [ ] **Step 2: Confirm the empty case is preserved (read-through, no code).** No migrations → `daily` is empty → `(SELECT min(day) FROM daily)` is `NULL` → `generate_series(NULL, <today>, interval '1 day')` yields **0 rows** → `rows = []` → transform returns `{ timestamps: [], data: [] }`. This matches today's behavior. The missing-MFX-token early return (lines 64–72) is upstream of the query and is untouched.
+
+- [ ] **Step 3: Confirm the row→object transform is unchanged.** `rows.map(r => r.timestamp)` and `rows.map(r => r.cumulative)` still apply 1:1. `cumulative` stays a string (numeric column). No change to lines 110–113.
+
+### Output type — why timestamp parsing does not regress
+`min(day)` is a `timestamp without time zone` (it is `date_trunc('day', manifestDatetime)`); `date_trunc('day', now() AT TIME ZONE 'UTC')` is also `timestamp without time zone`. `generate_series(timestamp, timestamp, interval)` therefore returns `timestamp without time zone`, the **same type the current query emits** for `day`. So the pg driver maps the new `timestamp` column to JS `Date` exactly as before — no client-side `new Date(t)` behavior change.
+
+---
+
+## Performance — HARD requirements (must hold, not "nice to have")
+
+These are acceptance criteria, not guidelines. The implementation must satisfy all of them:
+
+1. **One SQL round trip.** Exactly one `manager.query(...)` call after the Token lookup. The spine generation, the zero-fill, and the cumulative are ALL inside this single statement. Explicitly forbidden: fetching the sparse series then looping per-day queries; filling gaps in JS with per-row DB access; any `for`/`map` that issues a query.
+2. **Aggregate before joining.** `daily` aggregates first (~N active days; 32 on nbhd 1) → tiny. The `spine` is one row per calendar day in range. The `LEFT JOIN daily ON daily.day = spine.day` is **1:1** (both sides are distinct midnight days) — no fan-out, no cross join.
+3. **Bounds computed once.** `(SELECT min(day) FROM daily)` and `date_trunc('day', now() AT TIME ZONE 'UTC')` are scalar subqueries evaluated a single time, not per row. `now()` is `STABLE` (one value per statement).
+4. **Window cost is fine.** `SUM(...) OVER (ORDER BY spine.day)` is O(n log n) over the spine (one sort + a single running aggregate). The spine is bounded by the calendar range.
+5. **Scale sanity.** Mainnet (neighborhood 6) may span a few years → ~1,000–2,000 daily spine points. Still one bounded query returning ~1–2k small rows. No per-row DB work, so cost grows linearly with calendar span, not with migration count squared.
+6. **CTE evaluated once.** `daily` is referenced twice (inside `spine`'s `min(day)` subquery and in the main `LEFT JOIN`). Postgres materializes a multiply-referenced CTE once, so the migration→details→transaction→block join runs a single time. No new per-row lookups beyond the joins the current query already performs.
+
+### EXPLAIN check (Task 3 owns running it)
+On the live DB, `EXPLAIN ANALYZE` of the new query must show:
+- A **single** scan of the migration/details/transaction/block joins feeding the `daily` aggregate (no repeated nested-loop re-scan of that join per spine row).
+- A `Function Scan` on `generate_series` for the spine.
+- A `WindowAgg` (and a `Sort`/`Hash`/`Merge` left join) over a bounded row count.
+- **No** nested-loop blow-up where row counts multiply (e.g. spine-rows × migration-rows). If a nested loop appears, it must be against the small materialized `daily`, not the raw join.
+
+---
+
+## Task 2: Update the unit test
+
+**File:** `server/src/neighborhoods/migrations/migrations.service.spec.ts`
+
+The tests mock `manager.query`, so they exercise the transform and the **emitted SQL string**, not the real fill. Update the SQL-shape assertions to the new query; keep the behavioral tests.
+
+- [ ] **Step 1: Update the "emits SQL" / shape assertions.** In the test that currently asserts (lines 65–66):
+  ```js
+  expect(sql).toMatch(/date_trunc\('day'/i);
+  expect(sql).toMatch(/SUM\(amount\) OVER \(ORDER BY day\)/i);
+  ```
+  Replace the second assertion (the old window over the sparse `daily`) and add the spine/fill markers. New assertions for the dense query:
+  ```js
+  expect(sql).toMatch(/date_trunc\('day'/i);                       // daily bucket (kept)
+  expect(sql).toMatch(/generate_series/i);                          // spine exists
+  expect(sql).toMatch(/now\(\) AT TIME ZONE 'UTC'/i);               // UTC today bound
+  expect(sql).toMatch(/LEFT JOIN\s+daily/i);                        // zero-fill join
+  expect(sql).toMatch(/SUM\(\s*COALESCE\(daily\.amount,\s*0\)\s*\) OVER \(ORDER BY spine\.day\)/i); // carry-forward
+  ```
+  Keep the `params` assertion `expect(params).toEqual([42, mfxAddrStr])` and the no-N+1 assertion `expect(migrationRepo.manager.query).toHaveBeenCalledTimes(1)`.
+
+- [ ] **Step 2: Keep the transform test as-is.** The "returns cumulative day-bucketed series in ASC order" test mocks 3 rows with `timestamp`/`cumulative` and asserts the `{timestamps,data}` output. The mock shape is unchanged by this work, so it stays green. (Optionally rename it to reflect that rows are now a dense spine, but the assertions need no change.)
+
+- [ ] **Step 3: Keep the COALESCE-shapes test.** The "COALESCEs symbol/amount across direct and multisig argument shapes" test still applies verbatim — the daily CTE's JSON extraction is unchanged. Leave it.
+
+- [ ] **Step 4: Keep the empty-token + warn-once tests.** "returns empty series when no MFX token exists" (asserts `query` NOT called) and "warns only once when MFX token is missing" are upstream of the SQL and unchanged.
+
+- [ ] **Step 5 (optional, if cheap): add a dense/empty mock test.** Since the actual SQL fill isn't run under mocks, a unit test can't prove the gaps are filled — that's the live-DB job in Task 3. Optionally add a test asserting that when `query` resolves `[]` the result is `{ timestamps: [], data: [] }` (documents the empty-spine contract at the service layer). Don't over-invest; the real coverage is the live-DB verification.
+
+---
+
+## Task 3: Verification (live DB + suites + EXPLAIN)
+
+> The DB container `burned-mfx-db-1` is **read-only** for us — run `SELECT`/`EXPLAIN` only, never mutate. Use `docker exec burned-mfx-db-1 psql -U admin -d talib -c '...'`.
+
+### A. Live-DB accuracy (neighborhood 1)
+Run the **new** query (or its building blocks) against the live DB and confirm:
+
+- [ ] **Point count ≈ 351, not 32.** Days from the first migration day (`2025-06-10`) through today UTC inclusive. As of 2026-05-26 that is `date '2026-05-26' - date '2025-06-10' + 1 = 351` rows. Confirm:
+  ```sql
+  SELECT count(*) FROM ( <new query> ) s;     -- expect ~351
+  ```
+  (Exact value = `(today_utc::date - 2025-06-10) + 1`; recompute for the actual run date. Must be ≫ 32.)
+
+- [ ] **Total (final cumulative) UNCHANGED.** The last row's `cumulative` must equal the current production total:
+  ```
+  3469397230140100  uMFX  ( = 3,469,397.23014 MFX )
+  ```
+  ```sql
+  SELECT cumulative FROM ( <new query> ) s ORDER BY timestamp DESC LIMIT 1;  -- expect 3469397230140100
+  ```
+  Cross-check it equals the **old** sparse query's final value (zero-fill must not change the total).
+
+- [ ] **Monotonic non-decreasing + flat across gaps.** Cumulative never decreases; it is constant across known quiet stretches (e.g. the documented max 172-day gap):
+  ```sql
+  SELECT bool_and(cumulative >= lag) FROM (
+    SELECT cumulative::numeric,
+           lag(cumulative::numeric) OVER (ORDER BY timestamp) AS lag
+    FROM ( <new query> ) s
+  ) q WHERE lag IS NOT NULL;                   -- expect t (true)
+  ```
+
+- [ ] **Per-day average corrected to ≈ 9,970 MFX/day (down from 111,916).** The headline figure is `calculateAverageRate(calculateRates(series, "per_day"))`. Over a dense daily spine the `per_day` window baseline is the previous day, so each rate point = that day's burn, and the mean ≈ `total / number_of_days`. Order-of-magnitude check on the DB:
+  ```sql
+  -- mean of daily increments (uMFX/day), should be ~9.97e9 uMFX = ~9,970 MFX
+  SELECT avg(cumulative::numeric - lag) FROM (
+    SELECT cumulative::numeric,
+           lag(cumulative::numeric) OVER (ORDER BY timestamp) AS lag
+    FROM ( <new query> ) s
+  ) q WHERE lag IS NOT NULL;
+  ```
+  Acceptance: result ≈ **9,970 MFX/day** (≈ `9.97e9` uMFX/day), i.e. `total / ~348`. Note the exact client number depends on `calculateRates` skipping the first point (it averages `n-1 ≈ 350` daily diffs whose sum is `total − firstDayBurn`), so expect it to land in the **~9,900–10,000 MFX/day** band — the point is the ~11× correction away from 111,916, and the total being unchanged. Confirm it is NOT ~111,916.
+
+### B. Performance / EXPLAIN
+- [ ] **EXPLAIN ANALYZE the new query** on `burned-mfx-db-1` and confirm the structure described in the Performance section: single feed into the `daily` aggregate, `Function Scan` for `generate_series`, a `WindowAgg` over a bounded row set, and **no nested-loop blow-up** multiplying spine rows by migration rows. Capture the plan output for the verification write-up.
+
+### C. Suites + types
+- [ ] **Fresh worktree bootstrap.** This worktree needs deps installed before tests run:
+  ```bash
+  npm install            # repo root
+  (cd client && npm install)
+  (cd server && npm install)
+  ```
+- [ ] **Server suite green:** `cd server && npm test` (or the jest invocation used in CI) — the updated `migrations.service.spec.ts` and the rest pass.
+- [ ] **Client suite green:** `cd client && npm test` — unchanged, must stay green (no client code changed).
+- [ ] **Types clean:** `tsc` clean on server (and client) — `npx tsc --noEmit` in each, or the repo's typecheck script.
+
+### D. Optional end-to-end (only if requested)
+- [ ] Rebuild the docker image from this worktree, recreate `talib-app-1` (network `burned-mfx_default`, `-p 3000:3000`, mount `/home/fmorency/dev/talib/.env.dev:/app/server/.env`), and confirm the rate card now shows ~9,970 MFX/day and the cumulative chart is a smooth daily line extending to today. **Do not touch `burned-mfx-db-1`.**
+
+---
+
+## Acceptance summary (the numbers that must hold)
+
+| Check | Before | After (expected) |
+|---|---|---|
+| Point count (nbhd 1) | 32 | ≈ 351 (`today − 2025-06-10 + 1`) |
+| Final cumulative (total) | 3469397230140100 uMFX | **3469397230140100 uMFX (unchanged)** |
+| Per-day average | 111,916 MFX/day | ≈ **9,970 MFX/day** (~9,900–10,000 band) |
+| SQL round trips per call | 1 | **1** (no N+1) |
+| Cumulative across gaps | n/a | monotonic, flat |
+| Server / client suites + tsc | green | **green** |
+
+---
+
+## Out of scope (do not change)
+- Controller, module, DTOs, `SeriesEntity`, client charts, `calculateRates`/`calculateAverageRate`.
+- The bytea→UTF-8 MFX address decode and the Token lookup.
+- The missing-token early-return and warn-once logging.
+- Any backfill before the first migration day (start = `min(day)`, no genesis backfill — per spec decision).

--- a/docs/specs/2026-05-26-burned-mfx-zero-fill-design.md
+++ b/docs/specs/2026-05-26-burned-mfx-zero-fill-design.md
@@ -1,0 +1,134 @@
+# Design: zero-fill the burned-MFX series
+
+**Date:** 2026-05-26
+**Status:** Approved (brainstormed with maintainer)
+**Scope:** Server only — `MigrationsService.getBurnedMfxSeries`. The endpoint response
+shape, the controller, and both client charts are unchanged.
+
+## Problem
+
+`getBurnedMfxSeries` returns a cumulative day-bucketed series, but it only emits a row
+for days that *had* a migration. On the live data (neighborhood 1) that is **32 active
+days spread across 348 calendar days**, with gaps between active days averaging **11.2
+days** (max **172 days**).
+
+The cumulative chart is unaffected in value (its last point is the true total), but the
+**rate chart is materially wrong**. `calculateRates` (client) assumes points are
+adjacent in time, so on a sparse series each "per day" window's diff actually spans the
+whole gap but is labelled as one day. Result: the per-day average reads **111,916
+MFX/day** when the true average daily burn is **~9,970 MFX/day** (total ÷ 348 days) — an
+~11.2× overstatement (exactly the mean gap). Per-week and per-month are distorted the
+same way.
+
+## Goal
+
+Emit a **dense daily series**: one point for every calendar day from the first migration
+day through **today (UTC)**, with the cumulative value carried forward (0 increment on
+days with no migrations). With daily-adjacent points, the client's windowed rate
+calculation becomes correct with **no client changes**.
+
+## Design
+
+Replace the SQL in `getBurnedMfxSeries`. Keep the per-day aggregation (the `daily` CTE),
+add a daily date spine and left-join onto it:
+
+```sql
+WITH daily AS (                       -- per-day burn totals (aggregation unchanged)
+  SELECT date_trunc('day', m."manifestDatetime") AS day,
+         SUM((COALESCE(
+           td.argument ->> 'amount',
+           td.argument -> 'transaction' -> 'argument' ->> 'amount'
+         ))::numeric) AS amount
+  FROM migration m
+  INNER JOIN transaction_details td ON td.id = m."detailsId"
+  INNER JOIN transaction t          ON t.id  = m."transactionId"
+  INNER JOIN block b                ON b.id  = t."blockId"
+                                     AND b."neighborhoodId" = $1
+  WHERE m."manifestDatetime" IS NOT NULL
+    AND COALESCE(
+      td.argument ->> 'symbol',
+      td.argument -> 'transaction' -> 'argument' ->> 'symbol'
+    ) = $2
+  GROUP BY date_trunc('day', m."manifestDatetime")
+),
+spine AS (                            -- every UTC day, first burn day -> today
+  SELECT generate_series(
+           (SELECT min(day) FROM daily),
+           date_trunc('day', (now() AT TIME ZONE 'UTC')),
+           interval '1 day'
+         ) AS day
+)
+SELECT
+  spine.day AS timestamp,
+  SUM(COALESCE(daily.amount, 0)) OVER (ORDER BY spine.day) AS cumulative
+FROM spine
+LEFT JOIN daily ON daily.day = spine.day
+ORDER BY spine.day ASC;
+```
+
+### Decisions
+
+- **Start:** first migration day (`min(day)` from `daily`). No backfill to genesis.
+- **End:** today in **UTC**, via `now() AT TIME ZONE 'UTC'` — correct regardless of the
+  DB session timezone, and consistent with the UTC-naive `manifestDatetime` (a
+  `timestamp without time zone` holding UTC wall-clock).
+- **Empty case preserved:** no migrations → `daily` empty → `min(day)` is `NULL` →
+  `generate_series(NULL, …)` yields 0 rows → `{ timestamps: [], data: [] }`. Same as
+  today, and the early-return when the MFX token row is missing is unchanged.
+- **Output type:** `timestamp` (midnight) values, matching the existing
+  `date_trunc('day', …)` output, so the service's row→`{timestamps, data}` transform and
+  the client's `new Date(t)` parsing are unaffected.
+
+## Performance — REQUIRED: no N+1, no per-row queries
+
+This must remain **one SQL round trip**. Hard requirements:
+
+- **Single query.** Do NOT fetch the sparse series and then loop issuing per-day queries,
+  and do NOT fill in application code with per-row DB access. The spine, the fill, and the
+  cumulative must all happen in the one query above.
+- **Aggregate before joining.** `daily` aggregates first (~N active days, tiny); the
+  spine is ~one row per calendar day in range; the `LEFT JOIN` is 1:1 on `day`. No cross
+  joins or fan-out.
+- **Bounds computed once.** `min(day)` and the today expression are scalar subqueries
+  evaluated a single time, not per row.
+- **Scale check.** Mainnet (neighborhood 6) may span a few years → ~1,000–2,000 daily
+  points. That is still one query returning a bounded result set; confirm it stays a
+  single indexed scan + window aggregate (check `EXPLAIN` shows no nested-loop blowup).
+  The window `SUM(...) OVER (ORDER BY day)` is O(n log n) on the spine — fine.
+- The migration→details→transaction→block joins are the same ones the current query
+  already uses; we add no new per-row lookups.
+
+## Effect on charts (no client code change)
+
+- **Cumulative chart:** smooth daily line, flat through quiet stretches, extending to
+  today. Final value unchanged (still the true total).
+- **Rate chart:** windows are now daily-adjacent, so per-day ≈ true daily burn, and the
+  trailing zero-burn days near today correctly pull recent rates toward 0. The headline
+  average becomes truthful.
+
+## Testing
+
+- **Unit (server, `migrations.service.spec.ts`):** the existing tests mock
+  `manager.query`, so the row→`{timestamps,data}` transform tests stay valid. Update the
+  "emits SQL" test to assert the new query shape (`generate_series`, `AT TIME ZONE 'UTC'`,
+  `LEFT JOIN`, `COALESCE(daily.amount, 0)`). Keep the empty-token and warn-once tests.
+- **Live-DB verification (against `burned-mfx-db-1`, neighborhood 1):** the SQL fill is
+  not exercised by the mocked unit tests, so verify the real query directly. Acceptance:
+  - Point count = days from `2025-06-10` through today UTC inclusive (≈ 351), **not** 32.
+  - Cumulative is monotonic non-decreasing and **flat** across known gaps.
+  - Final cumulative **unchanged**: `3469397230140100` uMFX (= **3,469,397.23014 MFX**).
+  - Recomputing the client rate over the dense series: per-day average ≈ **9,970 MFX/day**
+    (down from 111,916), with the long zero stretches reflected.
+- **Client suite + server suite both green**, `tsc` clean. (Fresh worktree needs
+  `npm install` at root, `client/`, and `server/` before running tests.)
+- **Optional end-to-end:** rebuild the docker image from this worktree and recreate
+  `talib-app-1` (network `burned-mfx_default`, `-p 3000:3000`, mount
+  `/home/fmorency/dev/talib/.env.dev:/app/server/.env`); confirm the rate card now shows
+  ~9,970 MFX/day. DB (`burned-mfx-db-1`) must not be touched.
+
+## Files
+
+- `server/src/neighborhoods/migrations/migrations.service.ts` — replace the SQL in
+  `getBurnedMfxSeries`.
+- `server/src/neighborhoods/migrations/migrations.service.spec.ts` — update the SQL-shape
+  assertion; add coverage for the dense/empty behavior at whatever level is practical.

--- a/docs/specs/2026-05-26-burned-mfx-zero-fill-design.md
+++ b/docs/specs/2026-05-26-burned-mfx-zero-fill-design.md
@@ -1,7 +1,12 @@
 # Design: zero-fill the burned-MFX series
 
 **Date:** 2026-05-26
-**Status:** Approved (brainstormed with maintainer)
+**Status:** Implemented (`5b2cfff`) & verified — QA PASS 2026-05-26. See
+[verification report](./2026-05-26-burned-mfx-zero-fill-verification.md). Live-DB
+(neighborhood 1): 351 dense points, cumulative monotonic & flat across gaps, final total
+unchanged at 3,469,397.23014 MFX, per-day rate 111,916 → 9,912.56 MFX/day; `EXPLAIN`
+shows a single bounded scan + window aggregate (7 ms, no N+1); all in-scope suites + tsc
+green.
 **Scope:** Server only — `MigrationsService.getBurnedMfxSeries`. The endpoint response
 shape, the controller, and both client charts are unchanged.
 

--- a/docs/specs/2026-05-26-burned-mfx-zero-fill-verification.md
+++ b/docs/specs/2026-05-26-burned-mfx-zero-fill-verification.md
@@ -1,0 +1,106 @@
+# Verification report: zero-fill the burned-MFX series
+
+**Date:** 2026-05-26
+**Verifier:** QA
+**Verdict:** ✅ **PASS** — all in-scope checks green.
+**Commit under test:** `5b2cfff` (`feat(burned-mfx): zero-fill the burned-MFX series with a dense daily spine`) on `feat/burned-mfx-zero-fill`.
+**Design spec:** [2026-05-26-burned-mfx-zero-fill-design.md](./2026-05-26-burned-mfx-zero-fill-design.md)
+
+Scope of the change (`git diff d13672e..HEAD`): only
+`server/src/neighborhoods/migrations/migrations.service.ts` (SQL replaced) and
+`migrations.service.spec.ts` (assertions updated + empty-case test). Endpoint shape,
+controller, transform, and both client charts unchanged.
+
+---
+
+## 1. Live-DB accuracy — `burned-mfx-db-1`, neighborhood 1 (read-only)
+
+Ran the implemented query directly against the live DB (MFX symbol/address for
+neighborhood 1 = `mqbh742x4s356ddaryrxaowt4wxtlocekzpufodvowrirfrqaaaaa3l`).
+
+| Check | Expected | Measured | Result |
+|---|---|---|---|
+| Dense point count | ≈351 (2025-06-10 → today UTC, inclusive), not 32 | **351** (first 2025-06-10, last 2026-05-26) | ✅ |
+| Old sparse active days | 32 | 32 | ✅ (baseline) |
+| Cumulative monotonic non-decreasing | 0 decreasing steps | **0** decreasing steps | ✅ |
+| Flat across gaps | flat on zero-burn days | **319 flat steps + 31 increasing** (+ first-day baseline = 32 active days) | ✅ |
+| Final cumulative UNCHANGED | 3469397230140100 uMFX | dense = sparse = **3469397230140100** uMFX (= **3,469,397.23014 MFX**) | ✅ exact cross-check |
+
+### Recomputed per-day rate (using the real client `calculateRates` + `calculateAverageRate`)
+
+The actual client functions from `client/src/utils/burn-rate.ts` were run over the live
+series (both old sparse and new dense), exported as JSON from the DB:
+
+| Series | Points | Final (MFX) | **per_day avg** | per_week | per_month |
+|---|---|---|---|---|---|
+| SPARSE (old) | 32 | 3,469,397.23014 | **111,916.00742 MFX/day** | 192,805.76 | 402,578.77 |
+| DENSE (new) | 351 | 3,469,397.23014 | **9,912.56065 MFX/day** | 70,016.78 | 331,638.38 |
+
+- New per-day average **9,912.56 MFX/day** (`9912560657543` uMFX) — within the
+  ~9,900–10,000 band. ✅
+- Old per-day average reproduces the design spec's stated wrong figure **111,916**
+  exactly. The fix is an **11.29× reduction** (≈ the 11.2-day mean gap). ✅
+- Final total identical in both series → cumulative chart value unchanged. ✅
+
+## 2. Performance — `EXPLAIN (ANALYZE, BUFFERS, VERBOSE)`
+
+Plan structure (no nested-loop / N+1 blowup):
+
+- **`CTE daily`** (migration→transaction_details→transaction→block joins) executes
+  **once** — `GroupAggregate`, `loops=1`, 32 rows out, driven by 62 filtered migration
+  rows via PK index scans. These are the **same joins the old sparse query already used**;
+  they are **not** multiplied by the spine.
+- **`min(day)`** computed once via `InitPlan 2` (scalar).
+- **spine** = `ProjectSet` over `generate_series` → 351 rows (Function-Scan equivalent).
+- **spine ⋈ daily** = **`Merge Left Join`**, 351 rows out, 1:1 on `day` — **not** a nested
+  loop; no fan-out.
+- **`WindowAgg`** `SUM(COALESCE(daily.amount,0)) OVER (ORDER BY spine.day)` over 351 rows,
+  Memory 17 kB.
+- **Execution Time: 7.101 ms**, Planning 1.212 ms, Buffers shared hit=678 read=72.
+
+Single SQL round trip; single bounded scan + window aggregate. **No N+1, no nested-loop
+blowup over the spine.** ✅ Scale note: the spine grows ~1 row/calendar-day (mainnet
+~1–2k rows) while the daily-CTE joins scale with *active* migrations, not calendar days —
+stays a bounded single-pass plan.
+
+## 3. Test suites + tsc
+
+| Suite / check | Result | Notes |
+|---|---|---|
+| Server jest (`npm test -w server`) | 9 passed / **1 failed** | only failure = `data/data.controller.spec.ts` (pre-existing, see §4) |
+| └ `migrations.service.spec.ts` (in scope) | **5/5 PASS** | incl. new dense-spine empty-case test; SQL-shape assertions updated to `generate_series` / `AT TIME ZONE 'UTC'` / `LEFT JOIN daily` / `SUM(COALESCE(daily.amount,0)) OVER (ORDER BY spine.day)` |
+| └ `migrations.controller.spec.ts` | PASS | |
+| Server tsc — **build config** (`tsconfig.build.json`, ships) | **exit 0, clean** | the modified service typechecks fine |
+| Server tsc — full (`tsconfig.json`, incl. `test/`) | exit 1 | only error = `test/app.e2e-spec.ts` (pre-existing, see §4) |
+| Client vitest (`npm test -w client`) | **3 files / 14 tests PASS** | only a non-failing React `act()` warning |
+| Client tsc (`tsc --noEmit`) | **exit 0, clean** | |
+
+Everything **in scope is green**.
+
+> Environment note for reviewers: this is an **npm workspaces** monorepo
+> (`workspaces: ["client","server"]`). Install with a single `npm ci` / `npm install` at
+> the **repo root** — running `npm install` separately inside `client/` and `server/`
+> concurrently races on the hoisted root `node_modules` and can leave a half-written
+> package (it left `@testing-library/jest-dom`'s nested `dom-accessibility-api` missing
+> its `.mjs` files, which broke vitest collection until a clean root `npm ci`).
+
+## 4. Two known pre-existing reds — independently confirmed unrelated
+
+Both failing files are **byte-identical to the parent commit** — `git diff d13672e..HEAD`
+shows commit `5b2cfff` touches only the two `migrations.*` files. Neither failing file is
+in the diff, so the failures cannot have been introduced by this change.
+
+1. **`server/src/data/data.controller.spec.ts`** — NestJS DI error: `Nest can't resolve
+   dependencies of the DataController ... "TransactionDetailsRepository" ... not available
+   in the RootTestModule`. Test-module wiring gap, unrelated to burned-MFX.
+2. **`server/test/app.e2e-spec.ts(19,12)` TS2349** — `'typeof supertest' has no call
+   signatures`. supertest typing issue; only surfaces under the full `tsconfig.json`
+   (tests), excluded from the shipping `tsconfig.build.json`.
+
+## Conclusion
+
+The implementation meets the design spec: the series is now a dense daily spine (351
+points to today UTC), cumulative is monotonic and flat across gaps, the final total is
+provably unchanged at 3,469,397.23014 MFX, the per-day rate drops from the bogus 111,916
+to a truthful 9,912.56 MFX/day, the query stays a single bounded scan + window aggregate
+(7 ms), and all in-scope tests + typechecks are green. **PASS.**

--- a/server/src/neighborhoods/migrations/migrations.service.spec.ts
+++ b/server/src/neighborhoods/migrations/migrations.service.spec.ts
@@ -62,9 +62,31 @@ describe("MigrationsService.getBurnedMfxSeries", () => {
     // No-N+1: at most 1 SQL after the Token lookup.
     expect(migrationRepo.manager.query).toHaveBeenCalledTimes(1);
     const [sql, params] = migrationRepo.manager.query.mock.calls[0];
-    expect(sql).toMatch(/date_trunc\('day'/i);
-    expect(sql).toMatch(/SUM\(amount\) OVER \(ORDER BY day\)/i);
+    expect(sql).toMatch(/date_trunc\('day'/i); // daily bucket (kept)
+    expect(sql).toMatch(/generate_series/i); // dense daily spine exists
+    expect(sql).toMatch(/now\(\) AT TIME ZONE 'UTC'/i); // UTC today bound
+    expect(sql).toMatch(/LEFT JOIN\s+daily/i); // zero-fill join
+    expect(sql).toMatch(
+      /SUM\(\s*COALESCE\(daily\.amount,\s*0\)\s*\) OVER \(ORDER BY spine\.day\)/i,
+    ); // carry-forward cumulative
     expect(params).toEqual([42, mfxAddrStr]);
+  });
+
+  it("returns an empty series when the dense-spine query yields no rows", async () => {
+    // No migrations -> `daily` is empty -> min(day) is NULL ->
+    // generate_series(NULL, today, '1 day') yields 0 rows -> query resolves [].
+    const mfxAddrBytes = Buffer.from(
+      "mqbh742x4s356ddaryrxaowt4wxtlocekzpufodvowrirfrqaaaaa3l",
+      "utf-8",
+    );
+
+    tokenRepo.findOne.mockResolvedValueOnce({ address: mfxAddrBytes });
+    migrationRepo.manager.query.mockResolvedValueOnce([]);
+
+    const result = await service.getBurnedMfxSeries(42);
+
+    expect(result).toEqual({ timestamps: [], data: [] });
+    expect(migrationRepo.manager.query).toHaveBeenCalledTimes(1);
   });
 
   it("emits SQL that COALESCEs symbol/amount across direct and multisig argument shapes", async () => {

--- a/server/src/neighborhoods/migrations/migrations.service.ts
+++ b/server/src/neighborhoods/migrations/migrations.service.ts
@@ -97,12 +97,20 @@ export class MigrationsService {
               td.argument -> 'transaction' -> 'argument' ->> 'symbol'
             ) = $2
           GROUP BY date_trunc('day', m."manifestDatetime")
+        ),
+        spine AS (
+          SELECT generate_series(
+                   (SELECT min(day) FROM daily),
+                   date_trunc('day', (now() AT TIME ZONE 'UTC')),
+                   interval '1 day'
+                 ) AS day
         )
         SELECT
-          day AS timestamp,
-          SUM(amount) OVER (ORDER BY day) AS cumulative
-        FROM daily
-        ORDER BY day ASC
+          spine.day AS timestamp,
+          SUM(COALESCE(daily.amount, 0)) OVER (ORDER BY spine.day) AS cumulative
+        FROM spine
+        LEFT JOIN daily ON daily.day = spine.day
+        ORDER BY spine.day ASC
       `,
       [neighborhoodId, mfxAddressStr],
     );


### PR DESCRIPTION
## Summary

Completes the Burned MFX work on the metrics page with three related changes:

1. **Cumulative chart headline** — show the running total (final cumulative point) as a `StatNumber` under the "Cumulative Burned MFX" title, matching the other metric charts.
2. **Rate chart headline** — show the **average burn rate** for the selected unit (`calculateAverageRate`) under the "MFX Burn Rate" title, e.g. `9,912.56 MFX / day`. Mirrors the manifest-dashboard burn-rate card.
3. **Accurate, zero-filled series (server)** — the fix that makes the rate headline truthful. `MigrationsService.getBurnedMfxSeries` previously emitted a point only on days that had a migration. On sparse data (neighborhood 1: 32 active days across 348 calendar days, mean gap 11.2d) the client's windowed `calculateRates` — which assumes time-adjacent points — overstated the per-day rate **~11×** (111,916 vs ~9,970 MFX/day). The series is now a **dense daily spine** from the first migration day through today (UTC), with the cumulative carried forward (0 increment on quiet days), so the windowed rate math is correct with **no client change**.

## Server change (the substantive one)

Single-round-trip SQL in `getBurnedMfxSeries`: keep the per-day `daily` aggregation, add a `generate_series` spine (`min(day)` → `now() AT TIME ZONE 'UTC'`), `LEFT JOIN daily` onto it, and carry forward via `SUM(COALESCE(daily.amount,0)) OVER (ORDER BY spine.day)`. Output aliases, params, the missing-token early return, and the row→`{timestamps,data}` transform are unchanged. Empty case preserved (`min(day)` NULL → 0 rows → `{[],[]}`).

### Performance — no N+1
`EXPLAIN ANALYZE` (neighborhood 1): the multiply-referenced `daily` CTE is **materialized once** (the migration→details→transaction→block join runs a single time), the spine↔daily join is a **Merge Left Join** (351 × 32, 1:1, no fan-out), followed by a single `WindowAgg`. **Execution time 6.6 ms.** No per-row/per-day queries; cost scales with calendar span, not migration count.

## Verification (live DB, neighborhood 1)

| Check | Result |
|---|---|
| Dense points | **351** (2025-06-10 → today UTC), was 32 |
| Final total | **3,469,397.23014 MFX** — unchanged |
| Per-day rate | 111,916 → **9,912.56 MFX/day** (~11× correction) |
| Cumulative | monotonic, flat across gaps |
| Query plan | materialized CTE + merge join + window agg, 6.6 ms, no N+1 |
| Suites + tsc | green |

Two unrelated test failures (`data.controller.spec.ts` NestJS DI; `app.e2e` supertest typing) are **pre-existing on `main`**, untouched by this work.

## Docs included
- Design spec: `docs/specs/2026-05-26-burned-mfx-zero-fill-design.md`
- Implementation plan: `docs/plans/2026-05-26-burned-mfx-zero-fill-plan.md`
- QA verification report: `docs/specs/2026-05-26-burned-mfx-zero-fill-verification.md`

## Notes
- Client charts read `VITE_MFX_NEIGHBORHOOD_ID` (already set in CI to `6`); local/this verification uses neighborhood `1`.
- No DB migrations; server change is query-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)